### PR TITLE
fix(self-signed): typos in TLS helm parameters

### DIFF
--- a/self-signed/main.tf
+++ b/self-signed/main.tf
@@ -33,7 +33,7 @@ module "cert-manager" {
   helm_values = concat([{
     cert-manager = {
       tlsCrt = base64encode(tls_self_signed_cert.root.cert_pem)
-      tlsKey = base64encode(tls_self_signed_cert.root.private_key_pem)
+      tlsKey = base64encode(tls_private_key.root.private_key_pem)
     }
   }], var.helm_values)
 }

--- a/self-signed/main.tf
+++ b/self-signed/main.tf
@@ -32,8 +32,8 @@ module "cert-manager" {
 
   helm_values = concat([{
     cert-manager = {
-      tlsCert = base64encode(tls_self_signed_cert.root.cert_pem)
-      tlsKey  = base64encode(tls_self_signed_cert.root.private_key_pem)
+      tlsCrt = base64encode(tls_self_signed_cert.root.cert_pem)
+      tlsKey = base64encode(tls_self_signed_cert.root.private_key_pem)
     }
   }], var.helm_values)
 }


### PR DESCRIPTION
This was badly renamed in d2334a93


Signed-off-by: Raphaël Pinson <raphael@isovalent.com>
