### PR TITLE
fix: remove read only attribut

### DIFF
--- a/self-signed/main.tf
+++ b/self-signed/main.tf
@@ -3,7 +3,6 @@ resource "tls_private_key" "root" {
 }
 
 resource "tls_self_signed_cert" "root" {
-  key_algorithm   = "ECDSA"
   private_key_pem = tls_private_key.root.private_key_pem
 
   subject {


### PR DESCRIPTION
The new version of the hashicorp/tls (currently version 4.0.2) has
marked attribut as read-only. The attribut key_algorithm can not be set.