### PR TITLE
fix(aks): sym link to version.tf so providers get declared

### DIFF
--- a/aks/versions.tf
+++ b/aks/versions.tf
@@ -1,0 +1,1 @@
+../versions.tf


### PR DESCRIPTION
fixes:

```
➜  terra git:(test-modules) ✗ terraform init -upgrade               
Upgrading modules...
Downloading git::https://github.com/camptocamp/devops-stack-module-aad-pod-identity.git/ for aad-pod-identity...
- aad-pod-identity in .terraform/modules/aad-pod-identity
Downloading git::https://github.com/camptocamp/devops-stack-module-argocd.git for argocd_bootstrap...
- argocd_bootstrap in .terraform/modules/argocd_bootstrap/bootstrap
Downloading git::https://github.com/camptocamp/devops-stack-module-cert-manager.git for cert-manager...
- cert-manager in .terraform/modules/cert-manager/aks
- cert-manager.cert-manager in .terraform/modules/cert-manager
Downloading registry.terraform.io/Azure/aks/azurerm 6.2.0 for clusters...
- clusters in .terraform/modules/clusters
Downloading git::https://github.com/camptocamp/devops-stack-module-traefik.git for ingress...
- ingress in .terraform/modules/ingress/aks
- ingress.traefik in .terraform/modules/ingress
There are some problems with the configuration, described below.

The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.
╷
│ Error: Reference to undefined provider
│ 
│   on devops-stack-green.tf line 170, in module "cert-manager":
│  170:     argocd = argocd.green
│ 
│ The child module does not declare any provider requirement with the local name "argocd".
│ 
│ If you also control the child module, you can add a required_providers entry named "argocd" with the source address "oboukili/argocd" to accept this provider configuration.

```