### PR TITLE
feat(wait): add dependency to var app_autosync

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "argocd_application" "this" {
     namespace = var.argocd_namespace
   }
 
-  wait = true
+  wait = var.app_autosync == { "allow_empty" = tobool(null), "prune" = tobool(null), "self_heal" = tobool(null) } ? false : true
 
   spec {
     project = argocd_project.this.metadata.0.name


### PR DESCRIPTION
if argocd sync is disabled, there is no reason to wait for resources to be deployed