### PR TITLE
feat: add variables for solvers configurations

### DIFF
--- a/aks/local.tf
+++ b/aks/local.tf
@@ -1,4 +1,37 @@
 locals {
+
+  default_solvers = {
+    dns01 = {
+      dns01 = {
+        azureDNS = {
+          subscriptionID    = split("/", data.azurerm_subscription.primary.id)[2]
+          resourceGroupName = var.dns_zone_resource_group_name
+          hostedZoneName    = var.base_domain
+          # Azure Cloud Environment, default to AzurePublicCloud
+          environment = "AzurePublicCloud"
+        }
+      }
+      selector = {
+        dnsZones = [var.base_domain]
+      }
+    }
+    http01 = {
+      http01 = {
+        ingress = {}
+      }
+    }
+  }
+
+  use_default_solvers = {
+    dns01 = var.use_default_dns01_solver
+    http01 = var.use_default_http01_solver
+  }
+
+  solvers = concat(
+    [ for each in ["dns01", "http01"] : local.default_solvers[each] if local.use_default_solvers[each] ],
+    var.custom_solver_configurations
+  )
+
   helm_values = [{
     cert-manager = {
       azureIdentity = {
@@ -11,22 +44,7 @@ locals {
           enabled = true
         }
         acme = {
-          solvers = [
-            {
-              dns01 = {
-                azureDNS = {
-                  subscriptionID    = split("/", data.azurerm_subscription.primary.id)[2]
-                  resourceGroupName = var.dns_zone_resource_group_name
-                  hostedZoneName    = var.base_domain
-                  # Azure Cloud Environment, default to AzurePublicCloud
-                  environment = "AzurePublicCloud"
-                }
-              }
-              selector = {
-                dnsZones = [var.base_domain]
-              }
-            },
-          ]
+          solvers = local.solvers
         }
       }
       replicaCount = 2

--- a/eks/locals.tf
+++ b/eks/locals.tf
@@ -1,6 +1,36 @@
 locals {
   assumable_role_arn = var.base_domain == null ? "" : module.iam_assumable_role_cert_manager.0.iam_role_arn
 
+
+  default_solvers = {
+    dns01 = {
+      dns01 = {
+        route53 = {
+          region = data.aws_region.current.name
+        }
+      }
+      selector = {
+        dnsZones = [for domain in local.all_domains : domain]
+      }
+    }
+    http01 = {
+      http01 = {
+        ingress = {}
+      }
+    }
+  }
+
+  use_default_solvers = {
+    dns01 = var.use_default_dns01_solver
+    http01 = var.use_default_http01_solver
+  }
+
+  solvers = concat(
+    [ for each in ["dns01", "http01"] : local.default_solvers[each] if local.use_default_solvers[each] ],
+    var.custom_solver_configurations
+  )
+
+
   helm_values = [{
     cert-manager = {
       serviceAccount = {
@@ -13,18 +43,7 @@ locals {
           enabled = true
         }
         acme = {
-          solvers = [
-            {
-              dns01 = {
-                route53 = {
-                  region = data.aws_region.current.name
-                }
-              }
-              selector = {
-                dnsZones = [for domain in local.all_domains : domain]
-              }
-            },
-          ]
+          solvers = local.solvers
         }
       }
     }

--- a/sks/local.tf
+++ b/sks/local.tf
@@ -1,4 +1,22 @@
 locals {
+
+  default_solvers = {
+    http01 = {
+      http01 = {
+        ingress = {}
+      }
+    }
+  }
+
+  use_default_solvers = {
+    http01 = var.use_default_http01_solver
+  }
+
+  solvers = concat(
+    [ for each in ["http01"] : local.default_solvers[each] if local.use_default_solvers[each] ],
+    var.custom_solver_configurations
+  )
+
   helm_values = [{
     cert-manager = {
       clusterIssuers = {
@@ -6,13 +24,7 @@ locals {
           enabled = true
         }
         acme = {
-          solvers = [
-            {
-              http01 = {
-                ingress = {}
-              }
-            }
-          ]
+          solvers = local.solvers
         }
       }
       affinity = {

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,24 @@ variable "namespace" {
   default = "cert-manager"
 }
 
+variable "use_default_dns01_solver" {
+  description = "Whether to use the default dns01 solver configuration."
+  type        = bool
+  default     = true
+}
+
+variable "use_default_http01_solver" {
+  description = "Whether to use the default http01 solver configuration."
+  type        = bool
+  default     = true
+}
+
+variable "custom_solver_configurations" {
+  description = "List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled)."
+  type        = list
+  default     = []
+}
+
 variable "helm_values" {
   description = "Helm values, passed as a list of HCL structures."
   type        = any


### PR DESCRIPTION
Two variables allow disabling the default dns01 and http01 solvers configurations respectively and a third one allows adding extra configurations. This should make the module easy enough to use for standard cases, and flexible enough for special ones.

BREAKING CHANGE: this commit reintroduces the http01 solver by default.

## Description of the changes

Most clusters are OK with the default configuration, but sometimes you want to override the default config only for the http01 or dns01 solver, which is not possible using the `helm_values` variable alone.

## Tests executed on which distribution(s)

- [ ] AKS (Azure)
- [X ] EKS (AWS)
- [ ] SKS (Exoscale)