### PR TITLE
docs: remove orphaned symbolic link

### DIFF
--- a/docs/modules/ROOT/pages/kind/README.adoc
+++ b/docs/modules/ROOT/pages/kind/README.adoc
@@ -1,1 +1,0 @@
-../../../../../kind/README.adoc


### PR DESCRIPTION
## Description of the changes

This PR removes an orphaned symbolic link that was blocking the publication of the new documentation.

## Breaking change

- [x] No
- [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
- [ ] Yes (in the module itself): _give an explanation of the breaking change_

## Tests executed on which distribution(s)

- [ ] KinD
- [ ] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)