### PR TITLE
fix(eks): iam policies for DNS validation with multiple domains

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,11 +5,11 @@
 
 The following providers are used by this module:
 
-- [[provider_utils]] <<provider_utils,utils>>
+- [[provider_null]] <<provider_null,null>>
 
 - [[provider_argocd]] <<provider_argocd,argocd>>
 
-- [[provider_null]] <<provider_null,null>>
+- [[provider_utils]] <<provider_utils,utils>>
 
 === Resources
 

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -16,7 +16,7 @@ module "iam_assumable_role_cert_manager" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "4.0.0"
   create_role                   = true
-  number_of_role_policy_arns    = 1
+  number_of_role_policy_arns    = length(local.all_domains)
   role_name                     = format("cert-manager-%s", var.cluster_name)
   provider_url                  = replace(var.cluster_oidc_issuer_url, "https://", "")
   role_policy_arns              = [for domain in local.all_domains : aws_iam_policy.cert_manager[domain].arn]


### PR DESCRIPTION

## Description of the changes

Fix eks iam policies for DNS validation with multiple domains. Only the first domain was added to the IAM role policies used by cert-manager to do DNS validation.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] EKS (AWS)