### PR TITLE
fix(sks)!: remove nodeAffinity config for SKS clusters

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -32,11 +32,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
+- [[provider_null]] <<provider_null,null>>
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
 
-- [[provider_null]] <<provider_null,null>>
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 === Resources
 
@@ -68,7 +68,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.0.0"`
+Default: `"v3.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -212,7 +212,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.0.0"`
+|`"v3.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -84,7 +84,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.0.0"`
+Default: `"v3.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -265,7 +265,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.0.0"`
+|`"v3.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,6 +1,6 @@
 ---
 name: "cert-manager"
-title: "Cert-manager Module"
+title: "cert-manager Module"
 version: true
 start_page: README.adoc
 nav:

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -84,7 +84,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.0.0"`
+Default: `"v3.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -258,7 +258,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.0.0"`
+|`"v3.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -37,7 +37,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.0.0"`
+Default: `"v3.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -167,7 +167,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.0.0"`
+|`"v3.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/self-signed/README.adoc
+++ b/self-signed/README.adoc
@@ -50,7 +50,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.0.0"`
+Default: `"v3.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -197,7 +197,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.0.0"`
+|`"v3.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -21,12 +21,6 @@ Version:
 
 The following input variables are required:
 
-==== [[input_router_pool_id]] <<input_router_pool_id,router_pool_id>>
-
-Description: SKS Node Pool ID for router nodes
-
-Type: `string`
-
 ==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 
 Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
@@ -43,7 +37,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.0.0"`
+Default: `"v3.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -164,12 +158,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a,a,a,a",options="header,autowidth"]
 |===
 |Name |Description |Type |Default |Required
-|[[input_router_pool_id]] <<input_router_pool_id,router_pool_id>>
-|SKS Node Pool ID for router nodes
-|`string`
-|n/a
-|yes
-
 |[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
@@ -179,7 +167,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.0.0"`
+|`"v3.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/sks/extra_variables.tf
+++ b/sks/extra_variables.tf
@@ -1,4 +1,0 @@
-variable "router_pool_id" {
-  type        = string
-  description = "SKS Node Pool ID for router nodes"
-}

--- a/sks/locals.tf
+++ b/sks/locals.tf
@@ -1,5 +1,4 @@
 locals {
-
   default_solvers = {
     http01 = {
       http01 = {
@@ -25,64 +24,6 @@ locals {
         }
         acme = {
           solvers = local.solvers
-        }
-      }
-      affinity = {
-        nodeAffinity = {
-          preferredDuringSchedulingIgnoredDuringExecution = [
-            {
-              weight = 100
-              preference = {
-                matchExpressions = [
-                  {
-                    key      = "node.exoscale.net/nodepool-id"
-                    operator = "NotIn"
-                    values   = [var.router_pool_id]
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      }
-      cainjector = {
-        affinity = {
-          nodeAffinity = {
-            preferredDuringSchedulingIgnoredDuringExecution = [
-              {
-                weight = 100
-                preference = {
-                  matchExpressions = [
-                    {
-                      key      = "node.exoscale.net/nodepool-id"
-                      operator = "NotIn"
-                      values   = [var.router_pool_id]
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        }
-      }
-      webhook = {
-        affinity = {
-          nodeAffinity = {
-            preferredDuringSchedulingIgnoredDuringExecution = [
-              {
-                weight = 100
-                preference = {
-                  matchExpressions = [
-                    {
-                      key      = "node.exoscale.net/nodepool-id"
-                      operator = "NotIn"
-                      values   = [var.router_pool_id]
-                    }
-                  ]
-                }
-              }
-            ]
-          }
         }
       }
     }


### PR DESCRIPTION
## Description of the changes

This PR makes the SKS variant compatible with the new SKS cluster module implementation. Since there is a taint on the router nodes, the cert-manager pods won't be deployed there anyway. Because of this I've removed the redundant NodeAffinity settings that existed before.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] SKS (Exoscale)