### PR TITLE
fix/refactor: reorder variables, add default argocd_namespace and add missing providers

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -34,11 +34,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -68,7 +68,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.0.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -213,7 +213,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.0.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/README.adoc
+++ b/README.adoc
@@ -26,13 +26,15 @@ The following requirements are needed by this module:
 
 - [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
 
+- [[requirement_null]] <<requirement_null,null>> (>= 3)
+
 - [[requirement_utils]] <<requirement_utils,utils>> (>= 1)
 
 === Providers
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>>
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
@@ -48,9 +50,9 @@ The following resources are used by this module:
 - https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.this] (resource)
 - https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml[utils_deep_merge_yaml.values] (data source)
 
-=== Required Inputs
+=== Optional Inputs
 
-The following input variables are required:
+The following input variables are optional (have default values):
 
 ==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 
@@ -58,9 +60,7 @@ Description: Namespace used by Argo CD where the Application and AppProject reso
 
 Type: `string`
 
-=== Optional Inputs
-
-The following input variables are optional (have default values):
+Default: `"argocd"`
 
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
@@ -77,30 +77,6 @@ Description: Namespace where the applications's Kubernetes resources should be c
 Type: `string`
 
 Default: `"cert-manager"`
-
-==== [[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
-
-Description: Whether to use the default dns01 solver configuration.
-
-Type: `bool`
-
-Default: `true`
-
-==== [[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
-
-Description: Whether to use the default http01 solver configuration.
-
-Type: `bool`
-
-Default: `true`
-
-==== [[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
-
-Description: List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
-
-Type: `list(any)`
-
-Default: `[]`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -158,6 +134,30 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
+
+Description: Whether to use the default dns01 solver configuration.
+
+Type: `bool`
+
+Default: `true`
+
+==== [[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
+
+Description: Whether to use the default http01 solver configuration.
+
+Type: `bool`
+
+Default: `true`
+
+==== [[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
+
+Description: List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
+
+Type: `list(any)`
+
+Default: `[]`
+
 === Outputs
 
 The following outputs are exported:
@@ -173,6 +173,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |===
 |Name |Version
 |[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_null]] <<requirement_null,null>> |>= 3
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
 
@@ -183,7 +184,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Name |Version
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
-|[[provider_null]] <<provider_null,null>> |n/a
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -206,8 +207,8 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
-|n/a
-|yes
+|`"argocd"`
+|no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
@@ -219,24 +220,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
 |`string`
 |`"cert-manager"`
-|no
-
-|[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
-|Whether to use the default dns01 solver configuration.
-|`bool`
-|`true`
-|no
-
-|[[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
-|Whether to use the default http01 solver configuration.
-|`bool`
-|`true`
-|no
-
-|[[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
-|List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
-|`list(any)`
-|`[]`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -287,6 +270,24 @@ object({
 |IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
+|no
+
+|[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
+|Whether to use the default dns01 solver configuration.
+|`bool`
+|`true`
+|no
+
+|[[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
+|Whether to use the default http01 solver configuration.
+|`bool`
+|`true`
+|no
+
+|[[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
+|List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
+|`list(any)`
+|`[]`
 |no
 
 |===

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -88,7 +88,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.0.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -270,7 +270,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.0.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -5,6 +5,8 @@ The following requirements are needed by this module:
 
 - [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
 
+- [[requirement_null]] <<requirement_null,null>> (>= 3)
+
 - [[requirement_utils]] <<requirement_utils,utils>> (>= 1)
 
 === Providers
@@ -68,15 +70,17 @@ Description: The OIDC issuer URL that is associated with the cluster.
 
 Type: `string`
 
+=== Optional Inputs
+
+The following input variables are optional (have default values):
+
 ==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 
 Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
 
 Type: `string`
 
-=== Optional Inputs
-
-The following input variables are optional (have default values):
+Default: `"argocd"`
 
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
@@ -93,30 +97,6 @@ Description: Namespace where the applications's Kubernetes resources should be c
 Type: `string`
 
 Default: `"cert-manager"`
-
-==== [[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
-
-Description: Whether to use the default dns01 solver configuration.
-
-Type: `bool`
-
-Default: `true`
-
-==== [[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
-
-Description: Whether to use the default http01 solver configuration.
-
-Type: `bool`
-
-Default: `true`
-
-==== [[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
-
-Description: List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
-
-Type: `list(any)`
-
-Default: `[]`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -174,6 +154,30 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
+
+Description: Whether to use the default dns01 solver configuration.
+
+Type: `bool`
+
+Default: `true`
+
+==== [[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
+
+Description: Whether to use the default http01 solver configuration.
+
+Type: `bool`
+
+Default: `true`
+
+==== [[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
+
+Description: List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
+
+Type: `list(any)`
+
+Default: `[]`
+
 === Outputs
 
 The following outputs are exported:
@@ -189,6 +193,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |===
 |Name |Version
 |[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_null]] <<requirement_null,null>> |>= 3
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
 
@@ -259,8 +264,8 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
-|n/a
-|yes
+|`"argocd"`
+|no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
@@ -272,24 +277,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
 |`string`
 |`"cert-manager"`
-|no
-
-|[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
-|Whether to use the default dns01 solver configuration.
-|`bool`
-|`true`
-|no
-
-|[[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
-|Whether to use the default http01 solver configuration.
-|`bool`
-|`true`
-|no
-
-|[[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
-|List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
-|`list(any)`
-|`[]`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -340,6 +327,24 @@ object({
 |IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
+|no
+
+|[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
+|Whether to use the default dns01 solver configuration.
+|`bool`
+|`true`
+|no
+
+|[[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
+|Whether to use the default http01 solver configuration.
+|`bool`
+|`true`
+|no
+
+|[[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
+|List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
+|`list(any)`
+|`[]`
 |no
 
 |===

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -5,6 +5,8 @@ The following requirements are needed by this module:
 
 - [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
 
+- [[requirement_null]] <<requirement_null,null>> (>= 3)
+
 - [[requirement_utils]] <<requirement_utils,utils>> (>= 1)
 
 === Providers
@@ -60,12 +62,6 @@ Description: n/a
 
 Type: `string`
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
 === Optional Inputs
 
 The following input variables are optional (have default values):
@@ -77,6 +73,14 @@ Description: Other domains used for Ingresses requiring a DNS-01 challenge for L
 Type: `list(string)`
 
 Default: `[]`
+
+==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
+
+Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
+
+Type: `string`
+
+Default: `"argocd"`
 
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
@@ -93,30 +97,6 @@ Description: Namespace where the applications's Kubernetes resources should be c
 Type: `string`
 
 Default: `"cert-manager"`
-
-==== [[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
-
-Description: Whether to use the default dns01 solver configuration.
-
-Type: `bool`
-
-Default: `true`
-
-==== [[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
-
-Description: Whether to use the default http01 solver configuration.
-
-Type: `bool`
-
-Default: `true`
-
-==== [[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
-
-Description: List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
-
-Type: `list(any)`
-
-Default: `[]`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -174,6 +154,30 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
+
+Description: Whether to use the default dns01 solver configuration.
+
+Type: `bool`
+
+Default: `true`
+
+==== [[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
+
+Description: Whether to use the default http01 solver configuration.
+
+Type: `bool`
+
+Default: `true`
+
+==== [[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
+
+Description: List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
+
+Type: `list(any)`
+
+Default: `[]`
+
 === Outputs
 
 The following outputs are exported:
@@ -189,6 +193,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |===
 |Name |Version
 |[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_null]] <<requirement_null,null>> |>= 3
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
 
@@ -252,8 +257,8 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
-|n/a
-|yes
+|`"argocd"`
+|no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
@@ -265,24 +270,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
 |`string`
 |`"cert-manager"`
-|no
-
-|[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
-|Whether to use the default dns01 solver configuration.
-|`bool`
-|`true`
-|no
-
-|[[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
-|Whether to use the default http01 solver configuration.
-|`bool`
-|`true`
-|no
-
-|[[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
-|List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
-|`list(any)`
-|`[]`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -333,6 +320,24 @@ object({
 |IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
+|no
+
+|[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
+|Whether to use the default dns01 solver configuration.
+|`bool`
+|`true`
+|no
+
+|[[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
+|Whether to use the default http01 solver configuration.
+|`bool`
+|`true`
+|no
+
+|[[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
+|List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
+|`list(any)`
+|`[]`
 |no
 
 |===

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -88,7 +88,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.0.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -263,7 +263,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.0.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -37,7 +37,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.0.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -168,7 +168,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.0.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -5,6 +5,8 @@ The following requirements are needed by this module:
 
 - [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
 
+- [[requirement_null]] <<requirement_null,null>> (>= 3)
+
 - [[requirement_utils]] <<requirement_utils,utils>> (>= 1)
 
 === Modules
@@ -17,9 +19,9 @@ Source: ../self-signed/
 
 Version:
 
-=== Required Inputs
+=== Optional Inputs
 
-The following input variables are required:
+The following input variables are optional (have default values):
 
 ==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 
@@ -27,9 +29,7 @@ Description: Namespace used by Argo CD where the Application and AppProject reso
 
 Type: `string`
 
-=== Optional Inputs
-
-The following input variables are optional (have default values):
+Default: `"argocd"`
 
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
@@ -46,30 +46,6 @@ Description: Namespace where the applications's Kubernetes resources should be c
 Type: `string`
 
 Default: `"cert-manager"`
-
-==== [[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
-
-Description: Whether to use the default dns01 solver configuration.
-
-Type: `bool`
-
-Default: `true`
-
-==== [[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
-
-Description: Whether to use the default http01 solver configuration.
-
-Type: `bool`
-
-Default: `true`
-
-==== [[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
-
-Description: List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
-
-Type: `list(any)`
-
-Default: `[]`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -127,6 +103,30 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
+
+Description: Whether to use the default dns01 solver configuration.
+
+Type: `bool`
+
+Default: `true`
+
+==== [[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
+
+Description: Whether to use the default http01 solver configuration.
+
+Type: `bool`
+
+Default: `true`
+
+==== [[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
+
+Description: List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
+
+Type: `list(any)`
+
+Default: `[]`
+
 === Outputs
 
 The following outputs are exported:
@@ -142,6 +142,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |===
 |Name |Version
 |[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_null]] <<requirement_null,null>> |>= 3
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
 
@@ -161,8 +162,8 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
-|n/a
-|yes
+|`"argocd"`
+|no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
@@ -174,24 +175,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
 |`string`
 |`"cert-manager"`
-|no
-
-|[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
-|Whether to use the default dns01 solver configuration.
-|`bool`
-|`true`
-|no
-
-|[[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
-|Whether to use the default http01 solver configuration.
-|`bool`
-|`true`
-|no
-
-|[[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
-|List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
-|`list(any)`
-|`[]`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -242,6 +225,24 @@ object({
 |IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
+|no
+
+|[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
+|Whether to use the default dns01 solver configuration.
+|`bool`
+|`true`
+|no
+
+|[[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
+|Whether to use the default http01 solver configuration.
+|`bool`
+|`true`
+|no
+
+|[[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
+|List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
+|`list(any)`
+|`[]`
 |no
 
 |===

--- a/self-signed/README.adoc
+++ b/self-signed/README.adoc
@@ -50,7 +50,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.0.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -198,7 +198,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.0.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/self-signed/README.adoc
+++ b/self-signed/README.adoc
@@ -5,6 +5,8 @@ The following requirements are needed by this module:
 
 - [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
 
+- [[requirement_null]] <<requirement_null,null>> (>= 3)
+
 - [[requirement_utils]] <<requirement_utils,utils>> (>= 1)
 
 === Providers
@@ -30,9 +32,9 @@ The following resources are used by this module:
 - https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.root] (resource)
 - https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert[tls_self_signed_cert.root] (resource)
 
-=== Required Inputs
+=== Optional Inputs
 
-The following input variables are required:
+The following input variables are optional (have default values):
 
 ==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 
@@ -40,9 +42,7 @@ Description: Namespace used by Argo CD where the Application and AppProject reso
 
 Type: `string`
 
-=== Optional Inputs
-
-The following input variables are optional (have default values):
+Default: `"argocd"`
 
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
@@ -59,30 +59,6 @@ Description: Namespace where the applications's Kubernetes resources should be c
 Type: `string`
 
 Default: `"cert-manager"`
-
-==== [[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
-
-Description: Whether to use the default dns01 solver configuration.
-
-Type: `bool`
-
-Default: `true`
-
-==== [[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
-
-Description: Whether to use the default http01 solver configuration.
-
-Type: `bool`
-
-Default: `true`
-
-==== [[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
-
-Description: List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
-
-Type: `list(any)`
-
-Default: `[]`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -140,6 +116,30 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
+
+Description: Whether to use the default dns01 solver configuration.
+
+Type: `bool`
+
+Default: `true`
+
+==== [[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
+
+Description: Whether to use the default http01 solver configuration.
+
+Type: `bool`
+
+Default: `true`
+
+==== [[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
+
+Description: List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
+
+Type: `list(any)`
+
+Default: `[]`
+
 === Outputs
 
 The following outputs are exported:
@@ -155,6 +155,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |===
 |Name |Version
 |[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_null]] <<requirement_null,null>> |>= 3
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
 
@@ -191,8 +192,8 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
-|n/a
-|yes
+|`"argocd"`
+|no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
@@ -204,24 +205,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
 |`string`
 |`"cert-manager"`
-|no
-
-|[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
-|Whether to use the default dns01 solver configuration.
-|`bool`
-|`true`
-|no
-
-|[[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
-|Whether to use the default http01 solver configuration.
-|`bool`
-|`true`
-|no
-
-|[[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
-|List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
-|`list(any)`
-|`[]`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -272,6 +255,24 @@ object({
 |IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
+|no
+
+|[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
+|Whether to use the default dns01 solver configuration.
+|`bool`
+|`true`
+|no
+
+|[[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
+|Whether to use the default http01 solver configuration.
+|`bool`
+|`true`
+|no
+
+|[[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
+|List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
+|`list(any)`
+|`[]`
 |no
 
 |===

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -37,7 +37,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.0.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -168,7 +168,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.0.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -5,6 +5,8 @@ The following requirements are needed by this module:
 
 - [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 4)
 
+- [[requirement_null]] <<requirement_null,null>> (>= 3)
+
 - [[requirement_utils]] <<requirement_utils,utils>> (>= 1)
 
 === Modules
@@ -17,9 +19,9 @@ Source: ../
 
 Version:
 
-=== Required Inputs
+=== Optional Inputs
 
-The following input variables are required:
+The following input variables are optional (have default values):
 
 ==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 
@@ -27,9 +29,7 @@ Description: Namespace used by Argo CD where the Application and AppProject reso
 
 Type: `string`
 
-=== Optional Inputs
-
-The following input variables are optional (have default values):
+Default: `"argocd"`
 
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
@@ -46,30 +46,6 @@ Description: Namespace where the applications's Kubernetes resources should be c
 Type: `string`
 
 Default: `"cert-manager"`
-
-==== [[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
-
-Description: Whether to use the default dns01 solver configuration.
-
-Type: `bool`
-
-Default: `true`
-
-==== [[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
-
-Description: Whether to use the default http01 solver configuration.
-
-Type: `bool`
-
-Default: `true`
-
-==== [[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
-
-Description: List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
-
-Type: `list(any)`
-
-Default: `[]`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -127,6 +103,30 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
+
+Description: Whether to use the default dns01 solver configuration.
+
+Type: `bool`
+
+Default: `true`
+
+==== [[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
+
+Description: Whether to use the default http01 solver configuration.
+
+Type: `bool`
+
+Default: `true`
+
+==== [[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
+
+Description: List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
+
+Type: `list(any)`
+
+Default: `[]`
+
 === Outputs
 
 The following outputs are exported:
@@ -142,6 +142,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |===
 |Name |Version
 |[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 4
+|[[requirement_null]] <<requirement_null,null>> |>= 3
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
 
@@ -161,8 +162,8 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
-|n/a
-|yes
+|`"argocd"`
+|no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
@@ -174,24 +175,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
 |`string`
 |`"cert-manager"`
-|no
-
-|[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
-|Whether to use the default dns01 solver configuration.
-|`bool`
-|`true`
-|no
-
-|[[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
-|Whether to use the default http01 solver configuration.
-|`bool`
-|`true`
-|no
-
-|[[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
-|List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
-|`list(any)`
-|`[]`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
@@ -242,6 +225,24 @@ object({
 |IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
+|no
+
+|[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
+|Whether to use the default dns01 solver configuration.
+|`bool`
+|`true`
+|no
+
+|[[input_use_default_http01_solver]] <<input_use_default_http01_solver,use_default_http01_solver>>
+|Whether to use the default http01 solver configuration.
+|`bool`
+|`true`
+|no
+
+|[[input_custom_solver_configurations]] <<input_custom_solver_configurations,custom_solver_configurations>>
+|List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled).
+|`list(any)`
+|`[]`
 |no
 
 |===

--- a/terraform.tf
+++ b/terraform.tf
@@ -8,5 +8,9 @@ terraform {
       source  = "cloudposse/utils"
       version = ">= 1"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3"
+    }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,7 @@
 variable "argocd_namespace" {
   description = "Namespace used by Argo CD where the Application and AppProject resources should be created."
   type        = string
+  default     = "argocd"
 }
 
 variable "target_revision" {
@@ -17,24 +18,6 @@ variable "namespace" {
   description = "Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist."
   type        = string
   default     = "cert-manager"
-}
-
-variable "use_default_dns01_solver" {
-  description = "Whether to use the default dns01 solver configuration."
-  type        = bool
-  default     = true
-}
-
-variable "use_default_http01_solver" {
-  description = "Whether to use the default http01 solver configuration."
-  type        = bool
-  default     = true
-}
-
-variable "custom_solver_configurations" {
-  description = "List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled)."
-  type        = list(any)
-  default     = []
 }
 
 variable "enable_service_monitor" {
@@ -78,3 +61,21 @@ variable "dependency_ids" {
 #######################
 ## Module variables
 #######################
+
+variable "use_default_dns01_solver" {
+  description = "Whether to use the default dns01 solver configuration."
+  type        = bool
+  default     = true
+}
+
+variable "use_default_http01_solver" {
+  description = "Whether to use the default http01 solver configuration."
+  type        = bool
+  default     = true
+}
+
+variable "custom_solver_configurations" {
+  description = "List of additional solver configurations, appended to the default dns01 and http01 solvers (if enabled)."
+  type        = list(any)
+  default     = []
+}


### PR DESCRIPTION
## Description of the changes

Put special module variables under their proper section and add the default to `argocd_namespace` variable.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] No