### PR TITLE
fix: use main module instead of the self-signed one

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -34,9 +34,9 @@ The following providers are used by this module:
 
 - [[provider_null]] <<provider_null,null>>
 
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
-
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
+
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
 
 === Resources
 
@@ -68,7 +68,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.1.0"`
+Default: `"v4.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -212,7 +212,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.1.0"`
+|`"v4.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -84,7 +84,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.1.0"`
+Default: `"v4.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -265,7 +265,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.1.0"`
+|`"v4.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -84,7 +84,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.1.0"`
+Default: `"v4.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -258,7 +258,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.1.0"`
+|`"v4.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -37,7 +37,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.1.0"`
+Default: `"v4.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -167,7 +167,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.1.0"`
+|`"v4.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/self-signed/README.adoc
+++ b/self-signed/README.adoc
@@ -50,7 +50,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.1.0"`
+Default: `"v4.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -197,7 +197,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.1.0"`
+|`"v4.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -13,7 +13,7 @@ The following Modules are called:
 
 ==== [[module_cert-manager]] <<module_cert-manager,cert-manager>>
 
-Source: ../self-signed/
+Source: ../
 
 Version:
 
@@ -37,7 +37,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.1.0"`
+Default: `"v4.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -150,7 +150,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a,a",options="header,autowidth"]
 |===
 |Name |Source |Version
-|[[module_cert-manager]] <<module_cert-manager,cert-manager>> |../self-signed/ |
+|[[module_cert-manager]] <<module_cert-manager,cert-manager>> |../ |
 |===
 
 = Inputs
@@ -167,7 +167,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.1.0"`
+|`"v4.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -1,5 +1,5 @@
 module "cert-manager" {
-  source = "../self-signed/"
+  source = "../"
 
   argocd_namespace = var.argocd_namespace
 


### PR DESCRIPTION
## Description of the changes

There's no reason to use the self-signed submodule in a recursive call.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] SKS (Exoscale)