### PR TITLE
fix/ci: fix autosync deactivation and add chart auto-updater workflow

### DIFF
--- a/.github/workflows/chart-update.yaml
+++ b/.github/workflows/chart-update.yaml
@@ -1,0 +1,46 @@
+---
+name: "chart-update"
+
+on:
+  schedule:
+  - cron: "0 7 * * 1-5"
+  
+  workflow_dispatch:
+    inputs:
+      update-strategy:
+        description: "Update strategy to use. Valid values are 'patch', 'minor' or 'major'"
+        type: choice
+        options:
+        - "patch"
+        - "minor"
+        - "major"
+        required: true
+      excluded-dependencies:
+        description: "Comma-separated list of dependencies to exclude from the update (i.e. 'dependency1,dependency2,dependency3')"
+        type: string
+        required: false
+        default: ""
+      dry-run:
+        description: "Activate dry-run mode"
+        type: boolean
+        required: false
+        default: true
+
+jobs:
+
+  chart-update-schedule:
+    if: ${{ github.event_name == 'schedule' }}
+    strategy:
+      matrix:
+        update-strategy: ["major", "minor"]
+    uses: camptocamp/devops-stack/.github/workflows/modules-chart-update.yaml@main
+    with:
+      update-strategy: ${{ matrix.update-strategy }}
+  
+  chart-update-manual:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    uses: camptocamp/devops-stack/.github/workflows/modules-chart-update.yaml@main
+    with:
+      update-strategy: ${{ inputs.update-strategy }}
+      excluded-dependencies: ${{ inputs.excluded-dependencies }}
+      dry-run: ${{ inputs.dry-run }}

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = devops-stack-module-cert-manager
 // Document attributes to replace along the document
-:chart-version: 1.11.2
+:cert-manager-chart-version: 1.11.2
 :chart-url: https://github.com/cert-manager/cert-manager/tree/master/deploy/charts/cert-manager
 
 A https://devops-stack.io[DevOps Stack] module for installing and configuring https://cert-manager.io/[cert-manager].
@@ -10,7 +10,7 @@ The cert-manager chart used by this module is shipped in this repository as well
 [cols="1,1,1",options="autowidth,header"]
 |===
 |Current Chart Version |Original Repository |Default Values
-|*{chart-version}* |{chart-url}[Chart] |https://artifacthub.io/packages/helm/cert-manager/cert-manager/{chart-version}?modal=values[`values.yaml`]
+|*{cert-manager-chart-version}* |{chart-url}[Chart] |https://artifacthub.io/packages/helm/cert-manager/cert-manager/{chart-version}?modal=values[`values.yaml`]
 |===
 
 *Since this module is meant to be instantiated using its variants, the usage documentation is available in each variant* ( xref:./aks/README.adoc[AKS] | xref:./eks/README.adoc[EKS] | xref:./scaleway/README.adoc[Scaleway] | xref:./self-signed/README.adoc[Self-signed] | xref:./sks/README.adoc[SKS] ).

--- a/README.adoc
+++ b/README.adoc
@@ -34,11 +34,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -68,7 +68,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.3"`
+Default: `"v5.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -219,7 +219,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.3"`
+|`"v5.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/README.adoc
+++ b/README.adoc
@@ -188,9 +188,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_utils]] <<provider_utils,utils>> |>= 1
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_null]] <<provider_null,null>> |>= 3
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_utils]] <<provider_utils,utils>> |>= 1
 |===
 
 = Resources

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -88,7 +88,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.3"`
+Default: `"v5.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -270,7 +270,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.3"`
+|`"v5.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/charts/cert-manager/Chart.yaml
+++ b/charts/cert-manager/Chart.yaml
@@ -13,5 +13,5 @@ description: |
   NOTE: This chart must be instantiated in a sync-wave after the kube-prometheus-stack chart because it uses Prometheus Custom Resources.
 dependencies:
   - name: "cert-manager"
-    version: "^1"
+    version: "1.11.2"
     repository: "https://charts.jetstack.io"

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -88,7 +88,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.3"`
+Default: `"v5.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -263,7 +263,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.3"`
+|`"v5.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/main.tf
+++ b/main.tf
@@ -74,10 +74,13 @@ resource "argocd_application" "this" {
     }
 
     sync_policy {
-      automated {
-        prune       = var.app_autosync.prune
-        self_heal   = var.app_autosync.self_heal
-        allow_empty = var.app_autosync.allow_empty
+      dynamic "automated" {
+        for_each = toset(var.app_autosync == { "allow_empty" = tobool(null), "prune" = tobool(null), "self_heal" = tobool(null) } ? [] : [var.app_autosync])
+        content {
+          prune       = automated.value.prune
+          self_heal   = automated.value.self_heal
+          allow_empty = automated.value.allow_empty
+        }
       }
 
       retry {

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -37,7 +37,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.3"`
+Default: `"v5.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -168,7 +168,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.3"`
+|`"v5.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/self-signed/README.adoc
+++ b/self-signed/README.adoc
@@ -50,7 +50,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.3"`
+Default: `"v5.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -198,7 +198,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.3"`
+|`"v5.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -37,7 +37,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.3"`
+Default: `"v5.0.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -168,7 +168,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.3"`
+|`"v5.0.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>


### PR DESCRIPTION
## Description of the changes

This PR:
- re-adds the support to deactivate the auto-sync, which was broken by the use of dynamic Terraform blocks on the PR #59. This is not a breaking change, because users can still use the old way of passing an empty map to the `app_autosync` variable in order do deactivate the auto-sync.
- adds the workflow that enables the auto-upgrade of the Helm charts.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] EKS (AWS)
- [x] SKS (Exoscale)
- [x] KinD