### PR TITLE
feat: add variables to set AppProject, labels and destination cluster

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -36,9 +36,9 @@ The following providers are used by this module:
 
 - [[provider_null]] <<provider_null,null>> (>= 3)
 
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
-
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
+
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
 === Resources
 
@@ -69,6 +69,14 @@ Description: Name of the Argo CD AppProject where the Application should be crea
 Type: `string`
 
 Default: `null`
+
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
 
 ==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
 
@@ -204,9 +212,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_utils]] <<provider_utils,utils>> |>= 1
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_null]] <<provider_null,null>> |>= 3
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_utils]] <<provider_utils,utils>> |>= 1
 |===
 
 = Resources
@@ -236,6 +244,12 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
 |`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
 |no
 
 |[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>

--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,7 @@ The cert-manager chart used by this module is shipped in this repository as well
 [cols="1,1,1",options="autowidth,header"]
 |===
 |Current Chart Version |Original Repository |Default Values
-|*{cert-manager-chart-version}* |{chart-url}[Chart] |https://artifacthub.io/packages/helm/cert-manager/cert-manager/{chart-version}?modal=values[`values.yaml`]
+|*{cert-manager-chart-version}* |{chart-url}[Chart] |https://artifacthub.io/packages/helm/cert-manager/cert-manager/{cert-manager-chart-version}?modal=values[`values.yaml`]
 |===
 
 *Since this module is meant to be instantiated using its variants, the usage documentation is available in each variant* ( xref:./aks/README.adoc[AKS] | xref:./eks/README.adoc[EKS] | xref:./scaleway/README.adoc[Scaleway] | xref:./self-signed/README.adoc[Self-signed] | xref:./sks/README.adoc[SKS] ).

--- a/README.adoc
+++ b/README.adoc
@@ -34,11 +34,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 === Resources
 
@@ -212,9 +212,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
-|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources

--- a/README.adoc
+++ b/README.adoc
@@ -34,11 +34,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -92,7 +92,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v5.2.0"`
+Default: `"v5.2.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -212,9 +212,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -261,7 +261,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v5.2.0"`
+|`"v5.2.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/README.adoc
+++ b/README.adoc
@@ -36,9 +36,9 @@ The following providers are used by this module:
 
 - [[provider_null]] <<provider_null,null>> (>= 3)
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
-
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 === Resources
 
@@ -61,6 +61,22 @@ Description: Namespace used by Argo CD where the Application and AppProject reso
 Type: `string`
 
 Default: `"argocd"`
+
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
 
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
@@ -214,6 +230,18 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
 |`"argocd"`
+|no
+
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
 |no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -90,6 +90,14 @@ Type: `string`
 
 Default: `null`
 
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
 ==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
 
 Description: Destination cluster where the application should be deployed.
@@ -287,6 +295,12 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
 |`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
 |no
 
 |[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -82,6 +82,22 @@ Type: `string`
 
 Default: `"argocd"`
 
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
@@ -265,6 +281,18 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
 |`"argocd"`
+|no
+
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
 |no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -112,7 +112,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v5.2.0"`
+Default: `"v5.2.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -312,7 +312,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v5.2.0"`
+|`"v5.2.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -34,8 +34,9 @@ resource "azurerm_federated_identity_credential" "cert_manager" {
 module "cert-manager" {
   source = "../"
 
-  argocd_namespace = var.argocd_namespace
-
+  argocd_namespace       = var.argocd_namespace
+  argocd_project         = var.argocd_project
+  destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   namespace              = var.namespace
   enable_service_monitor = var.enable_service_monitor

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -36,6 +36,7 @@ module "cert-manager" {
 
   argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
+  argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   namespace              = var.namespace

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -112,7 +112,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v5.2.0"`
+Default: `"v5.2.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -305,7 +305,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v5.2.0"`
+|`"v5.2.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -90,6 +90,14 @@ Type: `string`
 
 Default: `null`
 
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
 ==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
 
 Description: Destination cluster where the application should be deployed.
@@ -280,6 +288,12 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
 |`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
 |no
 
 |[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -82,6 +82,22 @@ Type: `string`
 
 Default: `"argocd"`
 
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
@@ -258,6 +274,18 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
 |`"argocd"`
+|no
+
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
 |no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -77,6 +77,7 @@ module "cert-manager" {
 
   argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
+  argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   namespace              = var.namespace

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -75,8 +75,9 @@ data "aws_iam_policy_document" "cert_manager" {
 module "cert-manager" {
   source = "../"
 
-  argocd_namespace = var.argocd_namespace
-
+  argocd_namespace       = var.argocd_namespace
+  argocd_project         = var.argocd_project
+  destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   namespace              = var.namespace
   enable_service_monitor = var.enable_service_monitor

--- a/main.tf
+++ b/main.tf
@@ -75,7 +75,7 @@ resource "argocd_application" "this" {
     ignore_difference {
       group         = "admissionregistration.k8s.io"
       kind          = "ValidatingWebhookConfiguration"
-      name          = "cert-manager-webhook"
+      name          = format("%s-webhook", var.destination_cluster != "in-cluster" ? "cert-manager-${var.destination_cluster}" : "cert-manager")
       json_pointers = ["/webhooks/0/namespaceSelector/matchExpressions"]
     }
 

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,10 @@ resource "argocd_application" "this" {
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "cert-manager-${var.destination_cluster}" : "cert-manager"
     namespace = var.argocd_namespace
+    labels = merge({
+      "application" = "cert-manager"
+      "cluster"     = var.destination_cluster
+    }, var.argocd_labels)
   }
 
   wait = var.app_autosync == { "allow_empty" = tobool(null), "prune" = tobool(null), "self_heal" = tobool(null) } ? false : true

--- a/main.tf
+++ b/main.tf
@@ -3,8 +3,10 @@ resource "null_resource" "dependencies" {
 }
 
 resource "argocd_project" "this" {
+  count = var.argocd_project == null ? 1 : 0
+
   metadata {
-    name      = "cert-manager"
+    name      = var.destination_cluster != "in-cluster" ? "cert-manager-${var.destination_cluster}" : "cert-manager"
     namespace = var.argocd_namespace
     annotations = {
       "devops-stack.io/argocd_namespace" = var.argocd_namespace
@@ -12,16 +14,16 @@ resource "argocd_project" "this" {
   }
 
   spec {
-    description  = "cert-manager application project"
+    description  = "cert-manager application project for cluster ${var.destination_cluster}"
     source_repos = ["https://github.com/camptocamp/devops-stack-module-cert-manager.git"]
 
     destination {
-      name      = "in-cluster"
+      name      = var.destination_cluster
       namespace = var.namespace
     }
 
     destination {
-      name      = "in-cluster"
+      name      = var.destination_cluster
       namespace = "kube-system"
     }
 
@@ -43,14 +45,14 @@ data "utils_deep_merge_yaml" "values" {
 
 resource "argocd_application" "this" {
   metadata {
-    name      = "cert-manager"
+    name      = var.destination_cluster != "in-cluster" ? "cert-manager-${var.destination_cluster}" : "cert-manager"
     namespace = var.argocd_namespace
   }
 
   wait = var.app_autosync == { "allow_empty" = tobool(null), "prune" = tobool(null), "self_heal" = tobool(null) } ? false : true
 
   spec {
-    project = argocd_project.this.metadata.0.name
+    project = var.argocd_project == null ? argocd_project.this[0].metadata.0.name : var.argocd_project
 
     source {
       repo_url        = "https://github.com/camptocamp/devops-stack-module-cert-manager.git"
@@ -62,7 +64,7 @@ resource "argocd_application" "this" {
     }
 
     destination {
-      name      = "in-cluster"
+      name      = var.destination_cluster
       namespace = var.namespace
     }
 

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -61,7 +61,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v5.2.0"`
+Default: `"v5.2.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -210,7 +210,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v5.2.0"`
+|`"v5.2.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -31,6 +31,22 @@ Type: `string`
 
 Default: `"argocd"`
 
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
@@ -163,6 +179,18 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
 |`"argocd"`
+|no
+
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
 |no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -39,6 +39,14 @@ Type: `string`
 
 Default: `null`
 
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
 ==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
 
 Description: Destination cluster where the application should be deployed.
@@ -185,6 +193,12 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
 |`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
 |no
 
 |[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>

--- a/scaleway/main.tf
+++ b/scaleway/main.tf
@@ -3,6 +3,7 @@ module "cert-manager" {
 
   argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
+  argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   namespace              = var.namespace

--- a/scaleway/main.tf
+++ b/scaleway/main.tf
@@ -1,8 +1,9 @@
 module "cert-manager" {
   source = "../self-signed/"
 
-  argocd_namespace = var.argocd_namespace
-
+  argocd_namespace       = var.argocd_namespace
+  argocd_project         = var.argocd_project
+  destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   namespace              = var.namespace
   enable_service_monitor = var.enable_service_monitor

--- a/self-signed/README.adoc
+++ b/self-signed/README.adoc
@@ -44,6 +44,22 @@ Type: `string`
 
 Default: `"argocd"`
 
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
@@ -193,6 +209,18 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
 |`"argocd"`
+|no
+
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
 |no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>

--- a/self-signed/README.adoc
+++ b/self-signed/README.adoc
@@ -74,7 +74,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v5.2.0"`
+Default: `"v5.2.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -240,7 +240,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v5.2.0"`
+|`"v5.2.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/self-signed/README.adoc
+++ b/self-signed/README.adoc
@@ -52,6 +52,14 @@ Type: `string`
 
 Default: `null`
 
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
 ==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
 
 Description: Destination cluster where the application should be deployed.
@@ -215,6 +223,12 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
 |`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
 |no
 
 |[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>

--- a/self-signed/main.tf
+++ b/self-signed/main.tf
@@ -23,8 +23,9 @@ resource "tls_self_signed_cert" "root" {
 module "cert-manager" {
   source = "../"
 
-  argocd_namespace = var.argocd_namespace
-
+  argocd_namespace       = var.argocd_namespace
+  argocd_project         = var.argocd_project
+  destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   namespace              = var.namespace
   enable_service_monitor = var.enable_service_monitor

--- a/self-signed/main.tf
+++ b/self-signed/main.tf
@@ -25,6 +25,7 @@ module "cert-manager" {
 
   argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
+  argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   namespace              = var.namespace

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -61,7 +61,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v5.2.0"`
+Default: `"v5.2.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -210,7 +210,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v5.2.0"`
+|`"v5.2.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -31,6 +31,22 @@ Type: `string`
 
 Default: `"argocd"`
 
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
@@ -163,6 +179,18 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
 |`"argocd"`
+|no
+
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
 |no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -39,6 +39,14 @@ Type: `string`
 
 Default: `null`
 
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
 ==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
 
 Description: Destination cluster where the application should be deployed.
@@ -185,6 +193,12 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
 |`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
 |no
 
 |[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -1,8 +1,9 @@
 module "cert-manager" {
   source = "../"
 
-  argocd_namespace = var.argocd_namespace
-
+  argocd_namespace       = var.argocd_namespace
+  argocd_project         = var.argocd_project
+  destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   namespace              = var.namespace
   enable_service_monitor = var.enable_service_monitor

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -3,6 +3,7 @@ module "cert-manager" {
 
   argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
+  argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   namespace              = var.namespace

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,12 @@ variable "argocd_project" {
   default     = null
 }
 
+variable "argocd_labels" {
+  description = "Labels to attach to the Argo CD Application resource."
+  type        = map(string)
+  default     = {}
+}
+
 variable "destination_cluster" {
   description = "Destination cluster where the application should be deployed."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,18 @@ variable "argocd_namespace" {
   default     = "argocd"
 }
 
+variable "argocd_project" {
+  description = "Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application."
+  type        = string
+  default     = null
+}
+
+variable "destination_cluster" {
+  description = "Destination cluster where the application should be deployed."
+  type        = string
+  default     = "in-cluster"
+}
+
 variable "target_revision" {
   description = "Override of target revision of the application chart."
   type        = string


### PR DESCRIPTION
## Description of the changes

This PR:
- Adds the required variables and configuration to allow the module to be deployed on a different cluster than Argo CD.
- Adds the possibility of placing the application inside a specified Argo CD project in order to avoid having a single project for each application throughout multiple clusters.
- Adds labels and a variable to add more labels to the Argo CD application to make it easier to sort applications on the web interface of Argo CD.
- Fixes the values hyperlink on the documentation.

**All these changes are made in preparation for having a centralized Argo CD that controls applications throughout multiple clusters.**

:warning: **Do a _Rebase and merge_.**

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] KinD
- [x] EKS (AWS)
- [x] SKS (Exoscale)