### PR TITLE
fix(argocd-app): webhook issue

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -34,11 +34,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -68,7 +68,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v5.0.0"`
+Default: `"v5.2.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -188,9 +188,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -219,7 +219,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v5.0.0"`
+|`"v5.2.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -88,7 +88,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v5.0.0"`
+Default: `"v5.2.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -270,7 +270,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v5.0.0"`
+|`"v5.2.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -88,7 +88,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v5.0.0"`
+Default: `"v5.2.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -263,7 +263,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v5.0.0"`
+|`"v5.2.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ resource "argocd_application" "this" {
       group         = "admissionregistration.k8s.io"
       kind          = "ValidatingWebhookConfiguration"
       name          = "cert-manager-webhook"
-      json_pointers = ["/webhooks/0/namespaceSelector/matchExpressions/2"]
+      json_pointers = ["/webhooks/0/namespaceSelector/matchExpressions"]
     }
 
     sync_policy {

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -37,7 +37,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v5.0.0"`
+Default: `"v5.2.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -168,7 +168,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v5.0.0"`
+|`"v5.2.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/self-signed/README.adoc
+++ b/self-signed/README.adoc
@@ -50,7 +50,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v5.0.0"`
+Default: `"v5.2.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -198,7 +198,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v5.0.0"`
+|`"v5.2.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -37,7 +37,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v5.0.0"`
+Default: `"v5.2.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -168,7 +168,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v5.0.0"`
+|`"v5.2.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>


### PR DESCRIPTION
## Description of the changes
This PR addresses the problem where the ArgoCD application remains out of sync. This happens because the cluster introduces selectors that are unrecognized by ArgoCD, meaning they do not originate from the chart.


## Breaking change

- [x] No
- [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
- [ ] Yes (in the module itself): _give an explanation of the breaking change_

## Tests executed on which distribution(s)

- [x] KinD
- [x] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)