### PR TITLE
fix/feat: multiple modifications on the cert-manager issuers

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -50,6 +50,16 @@ The following resources are used by this module:
 - https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.this] (resource)
 - https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml[utils_deep_merge_yaml.values] (data source)
 
+=== Required Inputs
+
+The following input variables are required:
+
+==== [[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+
+Description: Email address used to register with Let's Encrypt.
+
+Type: `string`
+
 === Optional Inputs
 
 The following input variables are optional (have default values):
@@ -189,6 +199,10 @@ The following outputs are exported:
 ==== [[output_id]] <<output_id,id>>
 
 Description: ID to pass other modules in order to refer to this module as a dependency.
+
+==== [[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>>
+
+Description: List of cluster issuers created by cert-manager.
 // END_TF_DOCS
 
 === Reference in table format 
@@ -212,9 +226,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_utils]] <<provider_utils,utils>> |>= 1
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_null]] <<provider_null,null>> |>= 3
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_utils]] <<provider_utils,utils>> |>= 1
 |===
 
 = Resources
@@ -320,6 +334,12 @@ object({
 |`{}`
 |no
 
+|[[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+|Email address used to register with Let's Encrypt.
+|`string`
+|n/a
+|yes
+
 |[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
 |Whether to use the default dns01 solver configuration.
 |`bool`
@@ -346,6 +366,7 @@ object({
 |===
 |Name |Description
 |[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency.
+|[[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>> |List of cluster issuers created by cert-manager.
 |===
 // END_TF_TABLES
 ====

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -70,6 +70,12 @@ Description: The OIDC issuer URL that is associated with the cluster.
 
 Type: `string`
 
+==== [[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+
+Description: Email address used to register with Let's Encrypt.
+
+Type: `string`
+
 === Optional Inputs
 
 The following input variables are optional (have default values):
@@ -209,6 +215,10 @@ The following outputs are exported:
 ==== [[output_id]] <<output_id,id>>
 
 Description: ID to pass other modules in order to refer to this module as a dependency.
+
+==== [[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>>
+
+Description: List of cluster issuers created by cert-manager.
 // END_TF_DOCS
 // BEGIN_TF_TABLES
 = Requirements
@@ -371,6 +381,12 @@ object({
 |`{}`
 |no
 
+|[[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+|Email address used to register with Let's Encrypt.
+|`string`
+|n/a
+|yes
+
 |[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
 |Whether to use the default dns01 solver configuration.
 |`bool`
@@ -397,5 +413,6 @@ object({
 |===
 |Name |Description
 |[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency.
+|[[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>> |List of cluster issuers created by cert-manager.
 |===
 // END_TF_TABLES

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -46,5 +46,7 @@ module "cert-manager" {
 
   helm_values = concat(local.helm_values, var.helm_values)
 
+  letsencrypt_issuer_email = var.letsencrypt_issuer_email
+
   dependency_ids = var.dependency_ids
 }

--- a/aks/outputs.tf
+++ b/aks/outputs.tf
@@ -2,3 +2,8 @@ output "id" {
   description = "ID to pass other modules in order to refer to this module as a dependency."
   value       = module.cert-manager.id
 }
+
+output "cluster_issuers" {
+  description = "List of cluster issuers created by cert-manager."
+  value       = module.cert-manager.cluster_issuers
+}

--- a/charts/cert-manager/templates/clusterissuer.yaml
+++ b/charts/cert-manager/templates/clusterissuer.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: selfsigned-issuer
+  name: {{ $.Values.issuers.default.name | quote }}
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
@@ -13,7 +13,7 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: ca-issuer
+  name: {{ $.Values.issuers.ca.name | quote }}
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
@@ -23,7 +23,7 @@ spec:
 {{- if index $.Values "cert-manager" "clusterIssuers" }}
 {{- if index $.Values "cert-manager" "clusterIssuers" "letsencrypt" }}
 {{- if index $.Values "cert-manager" "clusterIssuers" "letsencrypt" "enabled" }}
-{{- range $name, $issuer := index $.Values "letsencrypt" "issuers" }}
+{{- range $name, $issuer := index $.Values "issuers" "letsencrypt" }}
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -62,6 +62,12 @@ Description: n/a
 
 Type: `string`
 
+==== [[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+
+Description: Email address used to register with Let's Encrypt.
+
+Type: `string`
+
 === Optional Inputs
 
 The following input variables are optional (have default values):
@@ -209,6 +215,10 @@ The following outputs are exported:
 ==== [[output_id]] <<output_id,id>>
 
 Description: ID to pass other modules in order to refer to this module as a dependency.
+
+==== [[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>>
+
+Description: List of cluster issuers created by cert-manager.
 // END_TF_DOCS
 // BEGIN_TF_TABLES
 = Requirements
@@ -364,6 +374,12 @@ object({
 |`{}`
 |no
 
+|[[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+|Email address used to register with Let's Encrypt.
+|`string`
+|n/a
+|yes
+
 |[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
 |Whether to use the default dns01 solver configuration.
 |`bool`
@@ -390,5 +406,6 @@ object({
 |===
 |Name |Description
 |[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency.
+|[[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>> |List of cluster issuers created by cert-manager.
 |===
 // END_TF_TABLES

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -87,5 +87,7 @@ module "cert-manager" {
 
   helm_values = concat(local.helm_values, var.helm_values)
 
+  letsencrypt_issuer_email = var.letsencrypt_issuer_email
+
   dependency_ids = var.dependency_ids
 }

--- a/eks/outputs.tf
+++ b/eks/outputs.tf
@@ -2,3 +2,8 @@ output "id" {
   description = "ID to pass other modules in order to refer to this module as a dependency."
   value       = module.cert-manager.id
 }
+
+output "cluster_issuers" {
+  description = "List of cluster issuers created by cert-manager."
+  value       = module.cert-manager.cluster_issuers
+}

--- a/locals.tf
+++ b/locals.tf
@@ -3,12 +3,12 @@ locals {
     letsencrypt = {
       production = {
         name   = "letsencrypt-prod"
-        email  = "letsencrypt@camptocamp.com"
+        email  = var.letsencrypt_issuer_email
         server = "https://acme-v02.api.letsencrypt.org/directory"
       }
       staging = {
         name   = "letsencrypt-staging"
-        email  = "letsencrypt@camptocamp.com"
+        email  = var.letsencrypt_issuer_email
         server = "https://acme-staging-v02.api.letsencrypt.org/directory"
       }
     }

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,11 @@
 locals {
   issuers = {
+    default = {
+      name = "selfsigned-issuer"
+    }
+    ca = { # This value is only used when using the self-signed variant.
+      name = "ca-issuer"
+    }
     letsencrypt = {
       production = {
         name   = "letsencrypt-prod"
@@ -26,8 +32,10 @@ locals {
         }
       }
     }
-    letsencrypt = {
-      issuers = { for issuer_id, issuer in local.issuers.letsencrypt :
+    issuers = {
+      default = local.issuers.default
+      ca      = local.issuers.ca
+      letsencrypt = { for issuer_id, issuer in local.issuers.letsencrypt :
         issuer.name => {
           email  = issuer.email
           server = issuer.server

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,19 @@
 locals {
+  issuers = {
+    letsencrypt = {
+      production = {
+        name   = "letsencrypt-prod"
+        email  = "letsencrypt@camptocamp.com"
+        server = "https://acme-v02.api.letsencrypt.org/directory"
+      }
+      staging = {
+        name   = "letsencrypt-staging"
+        email  = "letsencrypt@camptocamp.com"
+        server = "https://acme-staging-v02.api.letsencrypt.org/directory"
+      }
+    }
+  }
+
   helm_values = [{
     cert-manager = {
       installCRDs = true
@@ -12,14 +27,10 @@ locals {
       }
     }
     letsencrypt = {
-      issuers = {
-        letsencrypt-prod = {
-          email  = "letsencrypt@camptocamp.com"
-          server = "https://acme-v02.api.letsencrypt.org/directory"
-        }
-        letsencrypt-staging = {
-          email  = "letsencrypt@camptocamp.com"
-          server = "https://acme-staging-v02.api.letsencrypt.org/directory"
+      issuers = { for issuer_id, issuer in local.issuers.letsencrypt :
+        issuer.name => {
+          email  = issuer.email
+          server = issuer.server
         }
       }
     }

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,9 +6,9 @@ output "id" {
 output "cluster_issuers" {
   description = "List of cluster issuers created by cert-manager."
   value = merge({
-    default = "selfsigned-issuer"
+    default = local.issuers.default.name
     }, {
-    for issuer_id, issuer in { ca = "ca-issuer" } : issuer_id => issuer
+    for issuer_id, issuer in { ca = local.issuers.ca.name } : issuer_id => issuer
     if can(var.helm_values[0].cert-manager.tlsCrt) && can(var.helm_values[0].cert-manager.tlsKey)
     }, {
     for issuer_id, issuer in local.issuers.letsencrypt : issuer_id => issuer.name

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,16 @@ output "id" {
   description = "ID to pass other modules in order to refer to this module as a dependency."
   value       = resource.null_resource.this.id
 }
+
+output "cluster_issuers" {
+  description = "List of cluster issuers created by cert-manager."
+  value = merge({
+    default = "selfsigned-issuer"
+    }, {
+    for issuer_id, issuer in { ca = "ca-issuer" } : issuer_id => issuer
+    if can(var.helm_values[0].cert-manager.tlsCrt) && can(var.helm_values[0].cert-manager.tlsKey)
+    }, {
+    for issuer_id, issuer in local.issuers.letsencrypt : issuer_id => issuer.name
+    if var.helm_values[0].cert-manager.clusterIssuers.letsencrypt.enabled
+  })
+}

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -19,6 +19,16 @@ Source: ../self-signed/
 
 Version:
 
+=== Required Inputs
+
+The following input variables are required:
+
+==== [[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+
+Description: Email address used to register with Let's Encrypt.
+
+Type: `string`
+
 === Optional Inputs
 
 The following input variables are optional (have default values):
@@ -158,6 +168,10 @@ The following outputs are exported:
 ==== [[output_id]] <<output_id,id>>
 
 Description: ID to pass other modules in order to refer to this module as a dependency.
+
+==== [[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>>
+
+Description: List of cluster issuers created by cert-manager.
 // END_TF_DOCS
 // BEGIN_TF_TABLES
 = Requirements
@@ -269,6 +283,12 @@ object({
 |`{}`
 |no
 
+|[[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+|Email address used to register with Let's Encrypt.
+|`string`
+|n/a
+|yes
+
 |[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
 |Whether to use the default dns01 solver configuration.
 |`bool`
@@ -295,5 +315,6 @@ object({
 |===
 |Name |Description
 |[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency.
+|[[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>> |List of cluster issuers created by cert-manager.
 |===
 // END_TF_TABLES

--- a/scaleway/main.tf
+++ b/scaleway/main.tf
@@ -13,5 +13,7 @@ module "cert-manager" {
 
   helm_values = concat(local.helm_values, var.helm_values)
 
+  letsencrypt_issuer_email = var.letsencrypt_issuer_email
+
   dependency_ids = var.dependency_ids
 }

--- a/scaleway/outputs.tf
+++ b/scaleway/outputs.tf
@@ -2,3 +2,8 @@ output "id" {
   description = "ID to pass other modules in order to refer to this module as a dependency."
   value       = module.cert-manager.id
 }
+
+output "cluster_issuers" {
+  description = "List of cluster issuers created by cert-manager."
+  value       = module.cert-manager.cluster_issuers
+}

--- a/self-signed/README.adoc
+++ b/self-signed/README.adoc
@@ -32,6 +32,16 @@ The following resources are used by this module:
 - https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key[tls_private_key.root] (resource)
 - https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert[tls_self_signed_cert.root] (resource)
 
+=== Required Inputs
+
+The following input variables are required:
+
+==== [[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+
+Description: Email address used to register with Let's Encrypt.
+
+Type: `string`
+
 === Optional Inputs
 
 The following input variables are optional (have default values):
@@ -171,6 +181,14 @@ The following outputs are exported:
 ==== [[output_id]] <<output_id,id>>
 
 Description: ID to pass other modules in order to refer to this module as a dependency.
+
+==== [[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>>
+
+Description: List of cluster issuers created by cert-manager.
+
+==== [[output_ca_issuer_certificate]] <<output_ca_issuer_certificate,ca_issuer_certificate>>
+
+Description: The CA certificate used by the `ca-issuer`. You can copy this value into a `*.pem` file and use it as a CA certificate in your browser to avoid having insecure warnings.
 // END_TF_DOCS
 // BEGIN_TF_TABLES
 = Requirements
@@ -299,6 +317,12 @@ object({
 |`{}`
 |no
 
+|[[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+|Email address used to register with Let's Encrypt.
+|`string`
+|n/a
+|yes
+
 |[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
 |Whether to use the default dns01 solver configuration.
 |`bool`
@@ -325,5 +349,7 @@ object({
 |===
 |Name |Description
 |[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency.
+|[[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>> |List of cluster issuers created by cert-manager.
+|[[output_ca_issuer_certificate]] <<output_ca_issuer_certificate,ca_issuer_certificate>> |The CA certificate used by the `ca-issuer`. You can copy this value into a `*.pem` file and use it as a CA certificate in your browser to avoid having insecure warnings.
 |===
 // END_TF_TABLES

--- a/self-signed/locals.tf
+++ b/self-signed/locals.tf
@@ -1,0 +1,13 @@
+locals {
+  helm_values = [{
+    cert-manager = {
+      tlsCrt = base64encode(tls_self_signed_cert.root.cert_pem)
+      tlsKey = base64encode(tls_private_key.root.private_key_pem)
+      clusterIssuers = {
+        letsencrypt = {
+          enabled = false
+        }
+      }
+    }
+  }]
+}

--- a/self-signed/main.tf
+++ b/self-signed/main.tf
@@ -20,7 +20,6 @@ resource "tls_self_signed_cert" "root" {
   is_ca_certificate = true
 }
 
-
 module "cert-manager" {
   source = "../"
 
@@ -35,6 +34,8 @@ module "cert-manager" {
   app_autosync           = var.app_autosync
 
   helm_values = concat(local.helm_values, var.helm_values)
+
+  letsencrypt_issuer_email = var.letsencrypt_issuer_email
 
   dependency_ids = var.dependency_ids
 }

--- a/self-signed/main.tf
+++ b/self-signed/main.tf
@@ -1,13 +1,14 @@
 resource "tls_private_key" "root" {
-  algorithm = "ECDSA"
+  algorithm   = "ECDSA"
+  ecdsa_curve = "P256"
 }
 
 resource "tls_self_signed_cert" "root" {
   private_key_pem = tls_private_key.root.private_key_pem
 
   subject {
-    common_name  = "devops-stack.camptocamp.com"
-    organization = "Camptocamp, SA"
+    common_name  = "DevOps Stack"
+    organization = "Camptocamp"
   }
 
   validity_period_hours = 8760
@@ -33,12 +34,7 @@ module "cert-manager" {
   deep_merge_append_list = var.deep_merge_append_list
   app_autosync           = var.app_autosync
 
-  helm_values = concat([{
-    cert-manager = {
-      tlsCrt = base64encode(tls_self_signed_cert.root.cert_pem)
-      tlsKey = base64encode(tls_private_key.root.private_key_pem)
-    }
-  }], var.helm_values)
+  helm_values = concat(local.helm_values, var.helm_values)
 
   dependency_ids = var.dependency_ids
 }

--- a/self-signed/outputs.tf
+++ b/self-signed/outputs.tf
@@ -2,3 +2,14 @@ output "id" {
   description = "ID to pass other modules in order to refer to this module as a dependency."
   value       = module.cert-manager.id
 }
+
+output "cluster_issuers" {
+  description = "List of cluster issuers created by cert-manager."
+  value       = module.cert-manager.cluster_issuers
+}
+
+output "ca_issuer_certificate" {
+  description = "The CA certificate used by the `ca-issuer`. You can copy this value into a `*.pem` file and use it as a CA certificate in your browser to avoid having insecure warnings."
+  value       = trimspace(resource.tls_self_signed_cert.root.cert_pem)
+  sensitive   = true
+}

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -19,6 +19,16 @@ Source: ../
 
 Version:
 
+=== Required Inputs
+
+The following input variables are required:
+
+==== [[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+
+Description: Email address used to register with Let's Encrypt.
+
+Type: `string`
+
 === Optional Inputs
 
 The following input variables are optional (have default values):
@@ -158,6 +168,10 @@ The following outputs are exported:
 ==== [[output_id]] <<output_id,id>>
 
 Description: ID to pass other modules in order to refer to this module as a dependency.
+
+==== [[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>>
+
+Description: List of cluster issuers created by cert-manager.
 // END_TF_DOCS
 // BEGIN_TF_TABLES
 = Requirements
@@ -269,6 +283,12 @@ object({
 |`{}`
 |no
 
+|[[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+|Email address used to register with Let's Encrypt.
+|`string`
+|n/a
+|yes
+
 |[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
 |Whether to use the default dns01 solver configuration.
 |`bool`
@@ -295,5 +315,6 @@ object({
 |===
 |Name |Description
 |[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency.
+|[[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>> |List of cluster issuers created by cert-manager.
 |===
 // END_TF_TABLES

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -13,5 +13,7 @@ module "cert-manager" {
 
   helm_values = concat(local.helm_values, var.helm_values)
 
+  letsencrypt_issuer_email = var.letsencrypt_issuer_email
+
   dependency_ids = var.dependency_ids
 }

--- a/sks/outputs.tf
+++ b/sks/outputs.tf
@@ -2,3 +2,8 @@ output "id" {
   description = "ID to pass other modules in order to refer to this module as a dependency."
   value       = module.cert-manager.id
 }
+
+output "cluster_issuers" {
+  description = "List of cluster issuers created by cert-manager."
+  value       = module.cert-manager.cluster_issuers
+}

--- a/variables.tf
+++ b/variables.tf
@@ -80,6 +80,11 @@ variable "dependency_ids" {
 ## Module variables
 #######################
 
+variable "letsencrypt_issuer_email" {
+  description = "Email address used to register with Let's Encrypt."
+  type        = string
+}
+
 variable "use_default_dns01_solver" {
   description = "Whether to use the default dns01 solver configuration."
   type        = bool


### PR DESCRIPTION
## Description of the changes

1. In order to be able to retrieve the issuers and pass them in the other modules (instead of hardcoding it) I added an output "cluster_issuers". 

I took the opportunity to use a new local structure for the issuers and to loop over it inside the helm_values.

Example :

```
module "cert_manager" {
  source = "git::https://github.com/camptocamp/devops-stack-module-cert-manager.git

  argocd_namespace       = module.argocd_bootstrap.argocd_namespace
  enable_service_monitor = false
}

module "argocd" {
  source = "git::https://github.com/camptocamp/devops-stack-module-argocd.git"

  cluster_name   = "my-cluster"
  base_domain    = "my.domain"
  cluster_issuer = module.cert_manager.cluster_issuers.production

  ...
}
```

2. We've made some modifications to the root certificate we created for `ca-issuer`. This way I can output the certificate and add it to a browser so it trusts all the certificates issued by it (I had to change the elliptic curve because Firefox no longer trusted the default one).

3. We removed our e-mail from the Let's Encrypt configuration, otherwise we will receive expiration alerts for everyone that uses our DevOps Stack, even outside people.

## Breaking change

- [x] Yes: **the variable `letsencrypt_issuer_email` has no default value and will need to be set on the call to this module**

## Tests executed on which distribution(s)

- [X] K3S with self-signed variant
- [x] SKS (Exoscale)
