### PR TITLE
chore: propose some changes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -34,11 +34,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -158,6 +158,14 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+
+Description: Email address used to register with Let's Encrypt.
+
+Type: `string`
+
+Default: `"letsencrypt@example.org"`
+
 ==== [[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
 
 Description: Whether to use the default dns01 solver configuration.
@@ -190,9 +198,9 @@ The following outputs are exported:
 
 Description: ID to pass other modules in order to refer to this module as a dependency.
 
-==== [[output_issuers]] <<output_issuers,issuers>>
+==== [[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>>
 
-Description: List of issuers created by cert-manager
+Description: List of cluster issuers created by cert-manager.
 // END_TF_DOCS
 
 === Reference in table format 
@@ -216,9 +224,9 @@ Description: List of issuers created by cert-manager
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -324,6 +332,12 @@ object({
 |`{}`
 |no
 
+|[[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+|Email address used to register with Let's Encrypt.
+|`string`
+|`"letsencrypt@example.org"`
+|no
+
 |[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
 |Whether to use the default dns01 solver configuration.
 |`bool`
@@ -350,7 +364,7 @@ object({
 |===
 |Name |Description
 |[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency.
-|[[output_issuers]] <<output_issuers,issuers>> |List of issuers created by cert-manager
+|[[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>> |List of cluster issuers created by cert-manager.
 |===
 // END_TF_TABLES
 ====

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -178,6 +178,14 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+
+Description: Email address used to register with Let's Encrypt.
+
+Type: `string`
+
+Default: `"letsencrypt@example.org"`
+
 ==== [[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
 
 Description: Whether to use the default dns01 solver configuration.
@@ -210,9 +218,9 @@ The following outputs are exported:
 
 Description: ID to pass other modules in order to refer to this module as a dependency.
 
-==== [[output_issuers]] <<output_issuers,issuers>>
+==== [[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>>
 
-Description: List of issuers created by cert-manager
+Description: List of cluster issuers created by cert-manager.
 // END_TF_DOCS
 // BEGIN_TF_TABLES
 = Requirements
@@ -375,6 +383,12 @@ object({
 |`{}`
 |no
 
+|[[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+|Email address used to register with Let's Encrypt.
+|`string`
+|`"letsencrypt@example.org"`
+|no
+
 |[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
 |Whether to use the default dns01 solver configuration.
 |`bool`
@@ -401,6 +415,6 @@ object({
 |===
 |Name |Description
 |[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency.
-|[[output_issuers]] <<output_issuers,issuers>> |List of issuers created by cert-manager
+|[[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>> |List of cluster issuers created by cert-manager.
 |===
 // END_TF_TABLES

--- a/aks/outputs.tf
+++ b/aks/outputs.tf
@@ -3,7 +3,7 @@ output "id" {
   value       = module.cert-manager.id
 }
 
-output "issuers" {
-  description = "List of issuers created by cert-manager"
-  value       = module.cert-manager.issuers
+output "cluster_issuers" {
+  description = "List of cluster issuers created by cert-manager."
+  value       = module.cert-manager.cluster_issuers
 }

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -178,6 +178,14 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+
+Description: Email address used to register with Let's Encrypt.
+
+Type: `string`
+
+Default: `"letsencrypt@example.org"`
+
 ==== [[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
 
 Description: Whether to use the default dns01 solver configuration.
@@ -210,9 +218,9 @@ The following outputs are exported:
 
 Description: ID to pass other modules in order to refer to this module as a dependency.
 
-==== [[output_issuers]] <<output_issuers,issuers>>
+==== [[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>>
 
-Description: List of issuers created by cert-manager
+Description: List of cluster issuers created by cert-manager.
 // END_TF_DOCS
 // BEGIN_TF_TABLES
 = Requirements
@@ -368,6 +376,12 @@ object({
 |`{}`
 |no
 
+|[[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+|Email address used to register with Let's Encrypt.
+|`string`
+|`"letsencrypt@example.org"`
+|no
+
 |[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
 |Whether to use the default dns01 solver configuration.
 |`bool`
@@ -394,6 +408,6 @@ object({
 |===
 |Name |Description
 |[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency.
-|[[output_issuers]] <<output_issuers,issuers>> |List of issuers created by cert-manager
+|[[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>> |List of cluster issuers created by cert-manager.
 |===
 // END_TF_TABLES

--- a/eks/outputs.tf
+++ b/eks/outputs.tf
@@ -3,7 +3,7 @@ output "id" {
   value       = module.cert-manager.id
 }
 
-output "issuers" {
-  description = "List of issuers created by cert-manager"
-  value       = module.cert-manager.issuers
+output "cluster_issuers" {
+  description = "List of cluster issuers created by cert-manager."
+  value       = module.cert-manager.cluster_issuers
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,7 @@
 locals {
   issuers = {
     letsencrypt = {
-      prod = {
+      production = {
         name   = "letsencrypt-prod"
         email  = "letsencrypt@camptocamp.com"
         server = "https://acme-v02.api.letsencrypt.org/directory"

--- a/locals.tf
+++ b/locals.tf
@@ -3,12 +3,12 @@ locals {
     letsencrypt = {
       production = {
         name   = "letsencrypt-prod"
-        email  = "letsencrypt@camptocamp.com"
+        email  = var.letsencrypt_issuer_email
         server = "https://acme-v02.api.letsencrypt.org/directory"
       }
       staging = {
         name   = "letsencrypt-staging"
-        email  = "letsencrypt@camptocamp.com"
+        email  = var.letsencrypt_issuer_email
         server = "https://acme-staging-v02.api.letsencrypt.org/directory"
       }
     }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,15 @@ output "id" {
   value       = resource.null_resource.this.id
 }
 
-output "issuers" {
-  description = "List of issuers created by cert-manager"
-  value       = local.issuers
+output "cluster_issuers" {
+  description = "List of cluster issuers created by cert-manager."
+  value = merge({
+    default = "selfsigned-issuer"
+    }, {
+    for issuer_id, issuer in { ca = "ca-issuer" } : issuer_id => issuer
+    if can(var.helm_values[0].cert-manager.tlsCrt) && can(var.helm_values[0].cert-manager.tlsKey)
+    }, {
+    for issuer_id, issuer in local.issuers.letsencrypt : issuer_id => issuer.name
+    if var.helm_values[0].cert-manager.clusterIssuers.letsencrypt.enabled
+  })
 }

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -127,6 +127,14 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+
+Description: Email address used to register with Let's Encrypt.
+
+Type: `string`
+
+Default: `"letsencrypt@example.org"`
+
 ==== [[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
 
 Description: Whether to use the default dns01 solver configuration.
@@ -159,9 +167,9 @@ The following outputs are exported:
 
 Description: ID to pass other modules in order to refer to this module as a dependency.
 
-==== [[output_issuers]] <<output_issuers,issuers>>
+==== [[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>>
 
-Description: List of issuers created by cert-manager
+Description: List of cluster issuers created by cert-manager.
 // END_TF_DOCS
 // BEGIN_TF_TABLES
 = Requirements
@@ -273,6 +281,12 @@ object({
 |`{}`
 |no
 
+|[[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+|Email address used to register with Let's Encrypt.
+|`string`
+|`"letsencrypt@example.org"`
+|no
+
 |[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
 |Whether to use the default dns01 solver configuration.
 |`bool`
@@ -299,6 +313,6 @@ object({
 |===
 |Name |Description
 |[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency.
-|[[output_issuers]] <<output_issuers,issuers>> |List of issuers created by cert-manager
+|[[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>> |List of cluster issuers created by cert-manager.
 |===
 // END_TF_TABLES

--- a/scaleway/outputs.tf
+++ b/scaleway/outputs.tf
@@ -3,7 +3,7 @@ output "id" {
   value       = module.cert-manager.id
 }
 
-output "issuers" {
-  description = "List of issuers created by cert-manager"
-  value       = module.cert-manager.issuers
+output "cluster_issuers" {
+  description = "List of cluster issuers created by cert-manager."
+  value       = module.cert-manager.cluster_issuers
 }

--- a/self-signed/README.adoc
+++ b/self-signed/README.adoc
@@ -140,6 +140,14 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+
+Description: Email address used to register with Let's Encrypt.
+
+Type: `string`
+
+Default: `"letsencrypt@example.org"`
+
 ==== [[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
 
 Description: Whether to use the default dns01 solver configuration.
@@ -172,9 +180,13 @@ The following outputs are exported:
 
 Description: ID to pass other modules in order to refer to this module as a dependency.
 
-==== [[output_issuers]] <<output_issuers,issuers>>
+==== [[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>>
 
-Description: List of issuers created by cert-manager
+Description: List of cluster issuers created by cert-manager.
+
+==== [[output_ca_issuer_certificate]] <<output_ca_issuer_certificate,ca_issuer_certificate>>
+
+Description: The CA certificate used by the `ca-issuer`. You can copy this value into a `*.pem` file and use it as a CA certificate in your browser to avoid having insecure warnings.
 // END_TF_DOCS
 // BEGIN_TF_TABLES
 = Requirements
@@ -303,6 +315,12 @@ object({
 |`{}`
 |no
 
+|[[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+|Email address used to register with Let's Encrypt.
+|`string`
+|`"letsencrypt@example.org"`
+|no
+
 |[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
 |Whether to use the default dns01 solver configuration.
 |`bool`
@@ -329,6 +347,7 @@ object({
 |===
 |Name |Description
 |[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency.
-|[[output_issuers]] <<output_issuers,issuers>> |List of issuers created by cert-manager
+|[[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>> |List of cluster issuers created by cert-manager.
+|[[output_ca_issuer_certificate]] <<output_ca_issuer_certificate,ca_issuer_certificate>> |The CA certificate used by the `ca-issuer`. You can copy this value into a `*.pem` file and use it as a CA certificate in your browser to avoid having insecure warnings.
 |===
 // END_TF_TABLES

--- a/self-signed/locals.tf
+++ b/self-signed/locals.tf
@@ -1,0 +1,13 @@
+locals {
+  helm_values = [{
+    cert-manager = {
+      tlsCrt = base64encode(tls_self_signed_cert.root.cert_pem)
+      tlsKey = base64encode(tls_private_key.root.private_key_pem)
+      clusterIssuers = {
+        letsencrypt = {
+          enabled = false
+        }
+      }
+    }
+  }]
+}

--- a/self-signed/main.tf
+++ b/self-signed/main.tf
@@ -1,13 +1,14 @@
 resource "tls_private_key" "root" {
-  algorithm = "ECDSA"
+  algorithm   = "ECDSA"
+  ecdsa_curve = "P256"
 }
 
 resource "tls_self_signed_cert" "root" {
   private_key_pem = tls_private_key.root.private_key_pem
 
   subject {
-    common_name  = "devops-stack.camptocamp.com"
-    organization = "Camptocamp, SA"
+    common_name  = "DevOps Stack"
+    organization = "Camptocamp"
   }
 
   validity_period_hours = 8760
@@ -33,12 +34,7 @@ module "cert-manager" {
   deep_merge_append_list = var.deep_merge_append_list
   app_autosync           = var.app_autosync
 
-  helm_values = concat([{
-    cert-manager = {
-      tlsCrt = base64encode(tls_self_signed_cert.root.cert_pem)
-      tlsKey = base64encode(tls_private_key.root.private_key_pem)
-    }
-  }], var.helm_values)
+  helm_values = concat(local.helm_values, var.helm_values)
 
   dependency_ids = var.dependency_ids
 }

--- a/self-signed/outputs.tf
+++ b/self-signed/outputs.tf
@@ -3,7 +3,13 @@ output "id" {
   value       = module.cert-manager.id
 }
 
-output "issuers" {
-  description = "List of issuers created by cert-manager"
-  value       = module.cert-manager.issuers
+output "cluster_issuers" {
+  description = "List of cluster issuers created by cert-manager."
+  value       = module.cert-manager.cluster_issuers
+}
+
+output "ca_issuer_certificate" {
+  description = "The CA certificate used by the `ca-issuer`. You can copy this value into a `*.pem` file and use it as a CA certificate in your browser to avoid having insecure warnings."
+  value       = trimspace(resource.tls_self_signed_cert.root.cert_pem)
+  sensitive   = true
 }

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -127,6 +127,14 @@ Type: `map(string)`
 
 Default: `{}`
 
+==== [[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+
+Description: Email address used to register with Let's Encrypt.
+
+Type: `string`
+
+Default: `"letsencrypt@example.org"`
+
 ==== [[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
 
 Description: Whether to use the default dns01 solver configuration.
@@ -159,9 +167,9 @@ The following outputs are exported:
 
 Description: ID to pass other modules in order to refer to this module as a dependency.
 
-==== [[output_issuers]] <<output_issuers,issuers>>
+==== [[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>>
 
-Description: List of issuers created by cert-manager
+Description: List of cluster issuers created by cert-manager.
 // END_TF_DOCS
 // BEGIN_TF_TABLES
 = Requirements
@@ -273,6 +281,12 @@ object({
 |`{}`
 |no
 
+|[[input_letsencrypt_issuer_email]] <<input_letsencrypt_issuer_email,letsencrypt_issuer_email>>
+|Email address used to register with Let's Encrypt.
+|`string`
+|`"letsencrypt@example.org"`
+|no
+
 |[[input_use_default_dns01_solver]] <<input_use_default_dns01_solver,use_default_dns01_solver>>
 |Whether to use the default dns01 solver configuration.
 |`bool`
@@ -299,6 +313,6 @@ object({
 |===
 |Name |Description
 |[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency.
-|[[output_issuers]] <<output_issuers,issuers>> |List of issuers created by cert-manager
+|[[output_cluster_issuers]] <<output_cluster_issuers,cluster_issuers>> |List of cluster issuers created by cert-manager.
 |===
 // END_TF_TABLES

--- a/sks/outputs.tf
+++ b/sks/outputs.tf
@@ -3,7 +3,7 @@ output "id" {
   value       = module.cert-manager.id
 }
 
-output "issuers" {
-  description = "List of issuers created by cert-manager"
-  value       = module.cert-manager.issuers
+output "cluster_issuers" {
+  description = "List of cluster issuers created by cert-manager."
+  value       = module.cert-manager.cluster_issuers
 }

--- a/variables.tf
+++ b/variables.tf
@@ -80,6 +80,12 @@ variable "dependency_ids" {
 ## Module variables
 #######################
 
+variable "letsencrypt_issuer_email" {
+  description = "Email address used to register with Let's Encrypt."
+  type        = string
+  default     = "letsencrypt@example.org"
+}
+
 variable "use_default_dns01_solver" {
   description = "Whether to use the default dns01 solver configuration."
   type        = bool


### PR DESCRIPTION
## Description of the changes

This is my proposition. What this PR does:

- The output now takes into account the cluster issuers that are deployed and will output something like

```
cluster_issuers = {
  "ca" = "ca-issuer"
  "default" = "selfsigned-issuer"
}
```
... when using the `self-signed` variant OR something like

```
cluster_issuers = {
  "default" = "selfsigned-issuer"
  "production" = "letsencrypt-prod"
  "staging" = "letsencrypt-staging"
}
```
... when using any other variant.

- I've made some modifications to the root certificate we created for `ca-issuer`. This way I can output the certificate and add it to a browser so it trusts all the certificates issued by it (I had to change the elliptic curve because Firefox no longer trusted the default one).
- Some obsessive-compulsive changes on the output names and descriptions :smile:

I've also added a fix that I just now noticed... I removed our e-mail from the Let's Encrypt configuration, otherwise we will receive expiration alerts for everyone that uses our DevOps Stack, even outside people. I think nobody noticed this until now...

Let me know what you think, @lconsuegra ;)