### PR TITLE
fix!: change the default cluster issuer, remove the namespace variable, hardcode the Helm release name, fix dependency in identity

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -54,14 +54,6 @@ The following resources are used by this module:
 
 The following input variables are optional (have default values):
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
-Default: `"argocd"`
-
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -92,15 +84,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v7.0.0"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"cert-manager"`
+Default: `"v7.0.1"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -246,12 +230,6 @@ Description: List of cluster issuers created by cert-manager.
 [cols="a,a,a,a,a",options="header,autowidth"]
 |===
 |Name |Description |Type |Default |Required
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -273,13 +251,7 @@ Description: List of cluster issuers created by cert-manager.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v7.0.0"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"cert-manager"`
+|`"v7.0.1"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -13,6 +13,8 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_azurerm]] <<provider_azurerm,azurerm>>
 
 === Modules
@@ -32,6 +34,7 @@ The following resources are used by this module:
 - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential[azurerm_federated_identity_credential.cert_manager] (resource)
 - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment[azurerm_role_assignment.dns_zone_contributor] (resource)
 - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity[azurerm_user_assigned_identity.cert_manager] (resource)
+- https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.dependencies] (resource)
 - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/dns_zone[azurerm_dns_zone.this] (data source)
 - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.node_resource_group] (data source)
 - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription[azurerm_subscription.primary] (data source)
@@ -80,14 +83,6 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
-Default: `"argocd"`
-
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -118,15 +113,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v7.0.0"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"cert-manager"`
+Default: `"v7.0.1"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -244,6 +231,7 @@ Description: List of cluster issuers created by cert-manager.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_azurerm]] <<provider_azurerm,azurerm>> |n/a
 |===
 
@@ -263,6 +251,7 @@ Description: List of cluster issuers created by cert-manager.
 |https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential[azurerm_federated_identity_credential.cert_manager] |resource
 |https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment[azurerm_role_assignment.dns_zone_contributor] |resource
 |https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity[azurerm_user_assigned_identity.cert_manager] |resource
+|https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.dependencies] |resource
 |https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/dns_zone[azurerm_dns_zone.this] |data source
 |https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.node_resource_group] |data source
 |https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription[azurerm_subscription.primary] |data source
@@ -309,12 +298,6 @@ Description: List of cluster issuers created by cert-manager.
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -336,13 +319,7 @@ Description: List of cluster issuers created by cert-manager.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v7.0.0"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"cert-manager"`
+|`"v7.0.1"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/aks/locals.tf
+++ b/aks/locals.tf
@@ -34,10 +34,6 @@ locals {
 
   helm_values = [{
     cert-manager = {
-      # workload identity is suported since 1.11.0. TODO remove the hard-coded tag when upgrading to a chart that runs a cert-manager version higher than 1.11.0.
-      image = {
-        tag = "v1.11.0"
-      }
       podLabels = {
         "azure.workload.identity/use" = "true"
       }

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -38,7 +38,7 @@ resource "azurerm_federated_identity_credential" "cert_manager" {
   audience            = ["api://AzureADTokenExchange"]
   issuer              = var.cluster_oidc_issuer_url
   parent_id           = azurerm_user_assigned_identity.cert_manager.id
-  subject             = format("system:serviceaccount:%s:%s", var.namespace, var.destination_cluster != "in-cluster" ? "cert-manager-${var.destination_cluster}" : "cert-manager")
+  subject             = format("system:serviceaccount:%s:cert-manager", var.namespace)
 }
 
 module "cert-manager" {

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -44,7 +44,6 @@ resource "azurerm_federated_identity_credential" "cert_manager" {
 module "cert-manager" {
   source = "../"
 
-  argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -38,7 +38,7 @@ resource "azurerm_federated_identity_credential" "cert_manager" {
   audience            = ["api://AzureADTokenExchange"]
   issuer              = var.cluster_oidc_issuer_url
   parent_id           = azurerm_user_assigned_identity.cert_manager.id
-  subject             = format("system:serviceaccount:%s:cert-manager", var.namespace)
+  subject             = "system:serviceaccount:cert-manager:cert-manager"
 }
 
 module "cert-manager" {
@@ -49,7 +49,6 @@ module "cert-manager" {
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
-  namespace              = var.namespace
   enable_service_monitor = var.enable_service_monitor
   deep_merge_append_list = var.deep_merge_append_list
   app_autosync           = var.app_autosync

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -80,14 +80,6 @@ Type: `list(string)`
 
 Default: `[]`
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
-Default: `"argocd"`
-
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -118,15 +110,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v7.0.0"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"cert-manager"`
+Default: `"v7.0.1"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -302,12 +286,6 @@ Description: List of cluster issuers created by cert-manager.
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -329,13 +307,7 @@ Description: List of cluster issuers created by cert-manager.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v7.0.0"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"cert-manager"`
+|`"v7.0.1"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -80,7 +80,6 @@ module "cert-manager" {
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
-  namespace              = var.namespace
   enable_service_monitor = var.enable_service_monitor
   deep_merge_append_list = var.deep_merge_append_list
   app_autosync           = var.app_autosync

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -75,7 +75,6 @@ data "aws_iam_policy_document" "cert_manager" {
 module "cert-manager" {
   source = "../"
 
-  argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster

--- a/main.tf
+++ b/main.tf
@@ -7,10 +7,7 @@ resource "argocd_project" "this" {
 
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "cert-manager-${var.destination_cluster}" : "cert-manager"
-    namespace = var.argocd_namespace
-    annotations = {
-      "devops-stack.io/argocd_namespace" = var.argocd_namespace
-    }
+    namespace = "argocd"
   }
 
   spec {
@@ -46,7 +43,7 @@ data "utils_deep_merge_yaml" "values" {
 resource "argocd_application" "this" {
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "cert-manager-${var.destination_cluster}" : "cert-manager"
-    namespace = var.argocd_namespace
+    namespace = "argocd"
     labels = merge({
       "application" = "cert-manager"
       "cluster"     = var.destination_cluster

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ resource "argocd_project" "this" {
 
     destination {
       name      = var.destination_cluster
-      namespace = var.namespace
+      namespace = "cert-manager"
     }
 
     destination {
@@ -70,7 +70,7 @@ resource "argocd_application" "this" {
 
     destination {
       name      = var.destination_cluster
-      namespace = var.namespace
+      namespace = "cert-manager"
     }
 
     ignore_difference {

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,8 @@ resource "argocd_application" "this" {
       path            = "charts/cert-manager"
       target_revision = var.target_revision
       helm {
-        values = data.utils_deep_merge_yaml.values.output
+        release_name = "cert-manager"
+        values       = data.utils_deep_merge_yaml.values.output
       }
     }
 
@@ -75,7 +76,7 @@ resource "argocd_application" "this" {
     ignore_difference {
       group         = "admissionregistration.k8s.io"
       kind          = "ValidatingWebhookConfiguration"
-      name          = format("%s-webhook", var.destination_cluster != "in-cluster" ? "cert-manager-${var.destination_cluster}" : "cert-manager")
+      name          = "cert-manager-webhook"
       json_pointers = ["/webhooks/0/namespaceSelector/matchExpressions"]
     }
 

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -33,14 +33,6 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
-Default: `"argocd"`
-
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -71,15 +63,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v7.0.0"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"cert-manager"`
+Default: `"v7.0.1"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -211,12 +195,6 @@ Description: List of cluster issuers created by cert-manager.
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -238,13 +216,7 @@ Description: List of cluster issuers created by cert-manager.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v7.0.0"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"cert-manager"`
+|`"v7.0.1"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/scaleway/main.tf
+++ b/scaleway/main.tf
@@ -6,7 +6,6 @@ module "cert-manager" {
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
-  namespace              = var.namespace
   enable_service_monitor = var.enable_service_monitor
   deep_merge_append_list = var.deep_merge_append_list
   app_autosync           = var.app_autosync

--- a/scaleway/main.tf
+++ b/scaleway/main.tf
@@ -1,7 +1,6 @@
 module "cert-manager" {
   source = "../self-signed/"
 
-  argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster

--- a/self-signed/README.adoc
+++ b/self-signed/README.adoc
@@ -36,14 +36,6 @@ The following resources are used by this module:
 
 The following input variables are optional (have default values):
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
-Default: `"argocd"`
-
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -74,15 +66,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v7.0.0"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"cert-manager"`
+Default: `"v7.0.1"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -229,12 +213,6 @@ Description: The CA certificate used by the `ca-issuer`. You can copy this value
 [cols="a,a,a,a,a",options="header,autowidth"]
 |===
 |Name |Description |Type |Default |Required
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -256,13 +234,7 @@ Description: The CA certificate used by the `ca-issuer`. You can copy this value
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v7.0.0"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"cert-manager"`
+|`"v7.0.1"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/self-signed/main.tf
+++ b/self-signed/main.tf
@@ -28,7 +28,6 @@ module "cert-manager" {
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
-  namespace              = var.namespace
   enable_service_monitor = var.enable_service_monitor
   deep_merge_append_list = var.deep_merge_append_list
   app_autosync           = var.app_autosync

--- a/self-signed/main.tf
+++ b/self-signed/main.tf
@@ -23,7 +23,6 @@ resource "tls_self_signed_cert" "root" {
 module "cert-manager" {
   source = "../"
 
-  argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -33,14 +33,6 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
-Default: `"argocd"`
-
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -71,15 +63,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v7.0.0"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"cert-manager"`
+Default: `"v7.0.1"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -211,12 +195,6 @@ Description: List of cluster issuers created by cert-manager.
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -238,13 +216,7 @@ Description: List of cluster issuers created by cert-manager.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v7.0.0"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"cert-manager"`
+|`"v7.0.1"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -6,7 +6,6 @@ module "cert-manager" {
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
-  namespace              = var.namespace
   enable_service_monitor = var.enable_service_monitor
   deep_merge_append_list = var.deep_merge_append_list
   app_autosync           = var.app_autosync

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -1,7 +1,6 @@
 module "cert-manager" {
   source = "../"
 
-  argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster

--- a/variables.tf
+++ b/variables.tf
@@ -2,12 +2,6 @@
 ## Standard variables
 #######################
 
-variable "argocd_namespace" {
-  description = "Namespace used by Argo CD where the Application and AppProject resources should be created."
-  type        = string
-  default     = "argocd"
-}
-
 variable "argocd_project" {
   description = "Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -32,12 +32,6 @@ variable "target_revision" {
   default     = "v7.0.1" # x-release-please-version
 }
 
-variable "namespace" {
-  description = "Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist."
-  type        = string
-  default     = "cert-manager"
-}
-
 variable "enable_service_monitor" {
   description = "Enable Prometheus ServiceMonitor in the Helm chart."
   type        = bool


### PR DESCRIPTION
## Description of the changes

This PR does the following:

- **fix(aks): fix resource group dependency**

  I had some issues with the creation/destruction of the Azure identity, because Terraform would try to deploy the identity before the resource group existed so I added a null resource so we can also use the dependency ID to better manage this resource during deployment.

- **fix!: hardcode the release name to remove the destination cluster**

  I found out that Argo CD passes the name of the application as a value to set the Helm chart. This means that all the templating that used `{ $.Release.Name }` would resolve to the name given to Argo CD application.

  In a multicluster deployment, using a single Argo CD, the names of the applications must be different. We solved that by appending the cluster name to the default application name when deploying on different clusters than `in-cluster`. However, this resulted in multiple problems for deployments that depended on the name of the application being static, so this solves that.

  This is a breaking change because sometimes this requires an application to be deleted and recreated. 

- **fix!: remove the namespace variable**

  We found out that on multiple modules we were referencing resources from other modules using their default namespaces and this was hardcoded. In case someone decided to change the namespace of deployment of a certain application, this could break the way modules work with each other.

  We've decided that in order to avoid undefined behaviors caused by overloading this variable, it would be best to remove it entirely.

- **fix!: remove the ArgoCD namespace variable**

  Since we are hardcoding the namespace variable on all modules, the variable to set the ArgoCD namespace will no longer be needed as well.

- Change the default cluster issuer to the one that is in fact always created by the cert-manager module.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] Yes (in the module itself): because of the removal of the `namespace` and `argocd_namespace` variables and the fact that overloading the release name can force a recreation of the application.

## Tests executed on which distribution(s)

- [x] AKS (Azure)
- [x] EKS (AWS)
- [x] SKS (Exoscale)