### PR TITLE
fix(charts): add release in file name to avoid duplicates

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -84,7 +84,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v9.0.0"`
+Default: `"v9.0.1"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -268,9 +268,9 @@ Description: List of cluster issuers created by cert-manager.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 6
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -311,7 +311,7 @@ Description: List of cluster issuers created by cert-manager.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v9.0.0"`
+|`"v9.0.1"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -113,7 +113,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v9.0.0"`
+Default: `"v9.0.1"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -379,7 +379,7 @@ Description: List of cluster issuers created by cert-manager.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v9.0.0"`
+|`"v9.0.1"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/charts/cert-manager/templates/grafana-dashboard.yaml
+++ b/charts/cert-manager/templates/grafana-dashboard.yaml
@@ -13,7 +13,7 @@ items:
     labels:
       grafana_dashboard: '1'
   data:
-    {{ $dashboardName }}.json: {{ $.Files.Get $path | toJson }}
+    {{ $.Release.Name }}-{{ $dashboardName }}.json: {{ $.Files.Get $path | toJson }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -110,7 +110,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v9.0.0"`
+Default: `"v9.0.1"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -367,7 +367,7 @@ Description: List of cluster issuers created by cert-manager.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v9.0.0"`
+|`"v9.0.1"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/scaleway/README.adoc
+++ b/scaleway/README.adoc
@@ -63,7 +63,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v9.0.0"`
+Default: `"v9.0.1"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -276,7 +276,7 @@ Description: List of cluster issuers created by cert-manager.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v9.0.0"`
+|`"v9.0.1"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/self-signed/README.adoc
+++ b/self-signed/README.adoc
@@ -66,7 +66,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v9.0.0"`
+Default: `"v9.0.1"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -294,7 +294,7 @@ Description: The CA certificate used by the `ca-issuer`. You can copy this value
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v9.0.0"`
+|`"v9.0.1"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -63,7 +63,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v9.0.0"`
+Default: `"v9.0.1"`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
@@ -276,7 +276,7 @@ Description: List of cluster issuers created by cert-manager.
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v9.0.0"`
+|`"v9.0.1"`
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>


### PR DESCRIPTION
## Description of the changes

Grafana does not manage/support to have multiple dashboards with the same filename so I added the release name as a prefix to avoid duplicates with other modules.

## Breaking change

- [X] No
- [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
- [ ] Yes (in the module itself): _give an explanation of the breaking change_

## Tests executed on which distribution(s)

- [X] KinD
- [ ] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)